### PR TITLE
Work around name not always being set fast enough at startup

### DIFF
--- a/app/src/main/java/ltd/evilcorp/atox/App.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/App.kt
@@ -10,7 +10,7 @@ import javax.inject.Inject
 
 class App : Application(), HasActivityInjector {
     companion object {
-        lateinit var profile: String
+        var profile = "aTox user"
         lateinit var password: String
         lateinit var toxThread: ToxThread
     }


### PR DESCRIPTION
With this change, instead of a crash at startup, you'll have "aTox user" displayed in the sidebar instead of your actual name (if the Tox thread hasn't loaded the name).

This is just a workaround we should remove once we've made the name observable in some way.