### PR TITLE
Make messages look better

### DIFF
--- a/app/src/main/res/drawable/received_message_bubble.xml
+++ b/app/src/main/res/drawable/received_message_bubble.xml
@@ -2,5 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
        android:shape="rectangle">
     <solid android:color="@color/colorGray"/>
-    <corners android:topLeftRadius="5dp" android:radius="30dp"/>
+    <corners
+            android:topLeftRadius="@dimen/message_corner_radius_small"
+            android:radius="@dimen/message_corner_radius_large"/>
 </shape>

--- a/app/src/main/res/drawable/sent_message_bubble.xml
+++ b/app/src/main/res/drawable/sent_message_bubble.xml
@@ -2,5 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
        android:shape="rectangle">
     <solid android:color="@color/colorPrimary"/>
-    <corners android:topRightRadius="5dp" android:radius="30dp"/>
+    <corners
+            android:topRightRadius="@dimen/message_corner_radius_small"
+            android:radius="@dimen/message_corner_radius_large"/>
 </shape>

--- a/app/src/main/res/layout/message_received.xml
+++ b/app/src/main/res/layout/message_received.xml
@@ -12,6 +12,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="start"
             android:padding="8dp"
+            android:layout_marginEnd="@dimen/message_margin"
             android:gravity="start"
             android:textColor="@android:color/white"
             tools:text="Message I received"/>

--- a/app/src/main/res/layout/message_sent.xml
+++ b/app/src/main/res/layout/message_sent.xml
@@ -12,6 +12,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="end"
             android:padding="8dp"
+            android:layout_marginStart="@dimen/message_margin"
             android:gravity="end"
             android:textColor="@android:color/white"
             tools:text="Message I sent"/>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -4,4 +4,8 @@
     <dimen name="activity_vertical_margin">16dp</dimen>
     <dimen name="nav_header_vertical_spacing">8dp</dimen>
     <dimen name="nav_header_height">176dp</dimen>
+
+    <dimen name="message_corner_radius_small">5dp</dimen>
+    <dimen name="message_corner_radius_large">15dp</dimen>
+    <dimen name="message_margin">50dp</dimen>
 </resources>


### PR DESCRIPTION
Now they're less rounded and don't occupy 100% of the width of the screen.

Before
![before](https://user-images.githubusercontent.com/8304462/60219134-b2ccbf80-9871-11e9-9a17-77e62448b07d.png)

After
![after](https://user-images.githubusercontent.com/8304462/60218923-11de0480-9871-11e9-81ea-193eac55a7be.png)
