### PR TITLE
Remove unnecessary database accessors

### DIFF
--- a/app/src/main/java/ltd/evilcorp/atox/db/ContactDao.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/db/ContactDao.kt
@@ -21,9 +21,6 @@ interface ContactDao {
     @Query("SELECT * FROM contacts WHERE public_key = :publicKey")
     fun load(publicKey: ByteArray): LiveData<Contact>
 
-    @Query("SELECT * FROM contacts WHERE friend_number = :friendNumber")
-    fun load(friendNumber: Int): LiveData<Contact>
-
     @Query("SELECT * FROM contacts")
     fun loadAll(): LiveData<List<Contact>>
 }

--- a/app/src/main/java/ltd/evilcorp/atox/repository/ContactRepository.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/repository/ContactRepository.kt
@@ -30,10 +30,6 @@ class ContactRepository @Inject constructor(
         return contactDao.load(publicKey)
     }
 
-    fun get(friendNumber: Int): LiveData<Contact> {
-        return contactDao.load(friendNumber)
-    }
-
     fun getAll(): LiveData<List<Contact>> {
         return contactDao.loadAll()
     }


### PR DESCRIPTION
We're not going to want to use the friend number outside of the tox module, so being able to grab things out of the database using it isn't good.