### PR TITLE
Treat lint warnings as errors

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,6 +25,8 @@ android {
         targetCompatibility = '1.8'
     }
     lintOptions {
+        abortOnError true
+        warningsAsErrors true
         disable 'InvalidPackage' // TODO(robinlinden): Delete/update invalid packages
         disable 'GoogleAppIndexingWarning'
     }


### PR DESCRIPTION
I was hoping to treat the Android Studio lint warnings as errors in the CI system, but it turns out that they're a completely separate thing from the gradle lint, so that's not very convenient to do without installing the entire IDE.