### PR TITLE
Fix notifications opening the wrong chat

### DIFF
--- a/app/src/main/java/ltd/evilcorp/atox/ui/NotificationHelper.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/ui/NotificationHelper.kt
@@ -60,7 +60,7 @@ class NotificationHelper @Inject constructor(
             .setSmallIcon(android.R.drawable.sym_action_chat)
             .setContentTitle(contact.name)
             .setContentText(message)
-            .setContentIntent(PendingIntent.getActivity(context, 0, intent, 0))
+            .setContentIntent(PendingIntent.getActivity(context, contact.publicKey.hashCode(), intent, 0))
             .setCategory(Notification.CATEGORY_MESSAGE)
             .setAutoCancel(true)
 
@@ -74,7 +74,7 @@ class NotificationHelper @Inject constructor(
             .setSmallIcon(android.R.drawable.btn_star_big_on)
             .setContentTitle(context.getString(R.string.friend_request_from, friendRequest.publicKey))
             .setContentText(friendRequest.message)
-            .setContentIntent(PendingIntent.getActivity(context, 0, intent, 0))
+            .setContentIntent(PendingIntent.getActivity(context, friendRequest.publicKey.hashCode(), intent, 0))
             .setCategory(Notification.CATEGORY_MESSAGE)
             .setAutoCancel(true)
 


### PR DESCRIPTION
```
    /**
     * Retrieve a PendingIntent that will start a new activity, like calling
     * {@link Context#startActivity(Intent) Context.startActivity(Intent)}.
     * Note that the activity will be started outside of the context of an
     * existing activity, so you must use the {@link Intent#FLAG_ACTIVITY_NEW_TASK
     * Intent.FLAG_ACTIVITY_NEW_TASK} launch flag in the Intent.
     *
     * <p class="note">For security reasons, the {@link android.content.Intent}
     * you supply here should almost always be an <em>explicit intent</em>,
     * that is specify an explicit component to be delivered to through
     * {@link Intent#setClass(android.content.Context, Class) Intent.setClass}</p>
     *
     * @param context The Context in which this PendingIntent should start
     * the activity.
     * @param requestCode Private request code for the sender
     * @param intent Intent of the activity to be launched.
     * @param flags May be {@link #FLAG_ONE_SHOT}, {@link #FLAG_NO_CREATE},
     * {@link #FLAG_CANCEL_CURRENT}, {@link #FLAG_UPDATE_CURRENT},
     * or any of the flags as supported by
     * {@link Intent#fillIn Intent.fillIn()} to control which unspecified parts
     * of the intent that can be supplied when the actual send happens.
     *
     * @return Returns an existing or new PendingIntent matching the given
     * parameters.  May return null only if {@link #FLAG_NO_CREATE} has been
     * supplied.
     */
```

Turns out 2 intents to the same activity, but with different extras count as the same parameter.