### PR TITLE
Display typing status or last message in chat toolbar

### DIFF
--- a/app/src/main/java/ltd/evilcorp/atox/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/ui/chat/ChatFragment.kt
@@ -62,7 +62,14 @@ class ChatFragment : Fragment() {
             contactOnline = it.connectionStatus != ConnectionStatus.NONE
 
             title.text = contactName
+            subtitle.text = if (it.typing) {
+                getString(R.string.contact_typing)
+            } else {
+                // TODO(robinlinden): Replace with last seen.
+                it.lastMessage
+            }.toLowerCase()
             statusIndicator.setColorFilter(colorByStatus(resources, it))
+
             updateSendButton(this)
         })
 

--- a/app/src/main/res/layout/chat_fragment.xml
+++ b/app/src/main/res/layout/chat_fragment.xml
@@ -15,15 +15,28 @@
             android:background="@color/colorPrimary"
             android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
             app:navigationIcon="?attr/homeAsUpIndicator">
-            <include layout="@layout/profile_image_layout"/>
+        <include layout="@layout/profile_image_layout"/>
+        <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingStart="10dp"
+                android:paddingEnd="10dp"
+                android:orientation="vertical">
             <TextView
                     android:id="@+id/title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:paddingStart="10dp"
-                    android:paddingEnd="10dp"
+                    android:singleLine="true"
                     style="@style/TextAppearance.AppCompat.Widget.ActionBar.Title"
                     tools:text="Subject name here"/>
+            <TextView
+                    android:id="@+id/subtitle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:singleLine="true"
+                    style="@style/TextAppearance.AppCompat.Widget.ActionBar.Subtitle"
+                    tools:text="clever subtitle"/>
+        </LinearLayout>
     </android.widget.Toolbar>
     <ListView
             android:id="@+id/messages"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="cancel">Cancel</string>
     <string name="connected">Connected</string>
     <string name="connecting">Connecting…</string>
+    <string name="contact_typing">Typing…</string>
     <string name="create">Create</string>
     <string name="create_a_tox_profile">Create a Tox profile</string>
     <string name="delete_contact">Delete contact</string>


### PR DESCRIPTION
I wanted to display last seen, but getting that data in a reasonable way won't be trivial before we move the Tox stuff into a real service. (No way to run code when the app is killed otherwise.)

This is when a reasonable time format in the database would've came in handy:
![attempt 1](https://user-images.githubusercontent.com/8304462/61825453-b21f4d00-ae60-11e9-939b-55797257a4cd.png)

After removing some of the text:
![last message](https://user-images.githubusercontent.com/8304462/61825709-307bef00-ae61-11e9-85b5-bf8fdbd3c48b.png)
![last message never](https://user-images.githubusercontent.com/8304462/61825747-438ebf00-ae61-11e9-8a4d-f7439bcbc114.png)
![typing](https://user-images.githubusercontent.com/8304462/61825778-586b5280-ae61-11e9-80ce-43cae89a127e.png)
