### PR TITLE
Specify locale when changing case of strings

### DIFF
--- a/app/src/main/java/ltd/evilcorp/atox/tox/ToxUtil.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/tox/ToxUtil.kt
@@ -7,8 +7,9 @@ import im.tox.tox4j.core.options.SaveDataOptions
 import im.tox.tox4j.core.options.ToxOptions
 import ltd.evilcorp.core.vo.ConnectionStatus
 import ltd.evilcorp.core.vo.UserStatus
+import java.util.*
 
-fun String.hexToBytes(): ByteArray = this.chunked(2).map { it.toUpperCase().toInt(16).toByte() }.toByteArray()
+fun String.hexToBytes(): ByteArray = chunked(2).map { it.toUpperCase(Locale.ROOT).toInt(16).toByte() }.toByteArray()
 fun ByteArray.bytesToHex(): String = this.joinToString("") { "%02X".format(it) }
 fun ToxUserStatus.toUserStatus(): UserStatus = UserStatus.values()[this.ordinal]
 fun ToxConnection.toConnectionStatus(): ConnectionStatus = ConnectionStatus.values()[this.ordinal]

--- a/app/src/main/java/ltd/evilcorp/atox/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/ui/chat/ChatFragment.kt
@@ -24,6 +24,7 @@ import ltd.evilcorp.atox.ui.setAvatarFromContact
 import ltd.evilcorp.atox.vmFactory
 import ltd.evilcorp.core.vo.ConnectionStatus
 import ltd.evilcorp.core.vo.Message
+import java.util.*
 
 const val CONTACT_PUBLIC_KEY = "publicKey"
 
@@ -76,7 +77,7 @@ class ChatFragment : Fragment() {
             } else {
                 // TODO(robinlinden): Replace with last seen.
                 it.lastMessage
-            }.toLowerCase()
+            }.toLowerCase(Locale.getDefault())
             statusIndicator.setColorFilter(colorByStatus(resources, it))
             setAvatarFromContact(profileImage, it)
 

--- a/app/src/test/java/ltd/evilcorp/atox/ToxUtilTest.kt
+++ b/app/src/test/java/ltd/evilcorp/atox/ToxUtilTest.kt
@@ -10,6 +10,7 @@ import ltd.evilcorp.core.vo.ConnectionStatus
 import ltd.evilcorp.core.vo.UserStatus
 import org.junit.Assert.*
 import org.junit.Test
+import java.util.*
 
 private fun byteArrayOf(vararg bytes: Int) = ByteArray(bytes.size) { bytes[it].toByte() }
 
@@ -46,7 +47,7 @@ class ToxUtilTest {
     fun public_keys_can_be_converted() {
         val keyString = "76518406F6A9F2217E8DC487CC783C25CC16A15EB36FF32E335A235342C48A39"
         assert(keyString.hexToBytes().size == 32)
-        assertEquals(keyString, keyString.hexToBytes().bytesToHex().toUpperCase())
+        assertEquals(keyString, keyString.hexToBytes().bytesToHex().toUpperCase(Locale.ROOT))
 
         val keyBytes = byteArrayOf(
             0x76, 0x51, 0x84, 0x06, 0xF6, 0xA9, 0xF2, 0x21, 0x7E, 0x8D, 0xC4, 0x87, 0xCC, 0x78, 0x3C, 0x25,
@@ -57,13 +58,16 @@ class ToxUtilTest {
         assert(keyBytes.contentEquals(keyString.hexToBytes()))
 
         val anotherKeyString = "7B6704162C6532A5A8F0840A3680672D0E9D3E62B6419FFD88D9880669482169"
-        assertEquals(anotherKeyString, anotherKeyString.hexToBytes().bytesToHex().toUpperCase())
+        assertEquals(anotherKeyString, anotherKeyString.hexToBytes().bytesToHex().toUpperCase(Locale.ROOT))
         assertNotEquals(anotherKeyString.hexToBytes(), keyString.hexToBytes())
     }
 
     @Test
     fun casing_of_public_keys_does_not_matter() {
         val keyString = "76518406F6A9F2217E8DC487CC783C25CC16A15EB36FF32E335A235342C48A39"
-        assertArrayEquals(keyString.toUpperCase().hexToBytes(), keyString.toLowerCase().hexToBytes())
+        assertArrayEquals(
+            keyString.toUpperCase(Locale.ROOT).hexToBytes(),
+            keyString.toLowerCase(Locale.ROOT).hexToBytes()
+        )
     }
 }


### PR DESCRIPTION
This is to avoid things like hex strings being ruined in a locale that's decided that the uppercase of a is something like Á.