### PR TITLE
Don't treat lint warnings as errors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,8 +36,6 @@ android {
         freeCompilerArgs = listOf("-XXLanguage:+InlineClasses")
     }
     lintOptions {
-        isAbortOnError = true
-        isWarningsAsErrors = true
         // TODO(robinlinden): Delete/update invalid packages
         disable("InvalidPackage", "GoogleAppIndexingWarning", "MissingTranslation")
     }


### PR DESCRIPTION
This seemed like a good idea, but doesn't really work when lifting any
given library might cause your build to stop working with sometimes
false positive lint warnings.