### PR TITLE
Fix crash when accepting friend request

### DIFF
--- a/app/src/main/java/ltd/evilcorp/atox/tox/ToxWrapper.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/tox/ToxWrapper.kt
@@ -3,6 +3,7 @@ package ltd.evilcorp.atox.tox
 import android.util.Log
 import im.tox.tox4j.core.enums.ToxFileControl
 import im.tox.tox4j.core.enums.ToxMessageType
+import im.tox.tox4j.core.exceptions.ToxFriendAddException
 import im.tox.tox4j.impl.jni.ToxCoreImpl
 
 private const val TAG = "ToxWrapper"
@@ -81,9 +82,11 @@ class ToxWrapper(
 
     fun save() = saveManager.save(getPublicKey(), tox.savedata)
 
-    fun acceptFriendRequest(publicKey: PublicKey) {
+    fun acceptFriendRequest(publicKey: PublicKey) = try {
         tox.addFriendNorequest(publicKey.bytes())
         updateContactMapping()
+    } catch (e: ToxFriendAddException) {
+        Log.e(TAG, "Exception while accepting friend request $publicKey: $e")
     }
 
     fun startFileTransfer(publicKey: PublicKey, fileNumber: Int) =


### PR DESCRIPTION
You could have a friend add you and then add them, and then you'd be
left with a stray friend request that crashed the app if you accepted
it.