### PR TITLE
Don't let the ToxEventListener depend on everything

### DIFF
--- a/atox/src/main/java/ltd/evilcorp/atox/tox/EventListenerCallbacks.kt
+++ b/atox/src/main/java/ltd/evilcorp/atox/tox/EventListenerCallbacks.kt
@@ -1,0 +1,93 @@
+package ltd.evilcorp.atox.tox
+
+import ltd.evilcorp.atox.feature.FileTransferManager
+import ltd.evilcorp.atox.ui.NotificationHelper
+import ltd.evilcorp.core.repository.ContactRepository
+import ltd.evilcorp.core.repository.FriendRequestRepository
+import ltd.evilcorp.core.repository.MessageRepository
+import ltd.evilcorp.core.repository.UserRepository
+import ltd.evilcorp.core.vo.*
+import java.util.*
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private fun getDate() = Date().time
+
+@Singleton
+class EventListenerCallbacks @Inject constructor(
+    private val contactRepository: ContactRepository,
+    private val friendRequestRepository: FriendRequestRepository,
+    private val messageRepository: MessageRepository,
+    private val userRepository: UserRepository,
+    private val fileTransferManager: FileTransferManager,
+    private val notificationHelper: NotificationHelper,
+    private val tox: Tox
+) {
+    private var contacts: List<Contact> = listOf()
+
+    init {
+        contactRepository.getAll().observeForever {
+            contacts = it
+        }
+    }
+
+    private fun contactByPublicKey(publicKey: String) =
+        contacts.find { it.publicKey == publicKey }!!
+
+    fun setUp(listener: ToxEventListener) = with(listener) {
+        friendStatusMessageHandler = { publicKey, message ->
+            contactRepository.setStatusMessage(publicKey, message)
+        }
+
+        friendReadReceiptHandler = { publicKey, messageId ->
+            messageRepository.setReceipt(publicKey, messageId, getDate())
+        }
+
+        friendStatusHandler = { publicKey, status ->
+            contactRepository.setUserStatus(publicKey, status)
+        }
+
+        friendConnectionStatusHandler = { publicKey, status ->
+            contactRepository.setConnectionStatus(publicKey, status)
+        }
+
+        friendRequestHandler = { publicKey, _, message ->
+            FriendRequest(publicKey, message).also {
+                friendRequestRepository.add(it)
+                notificationHelper.showFriendRequestNotification(it)
+            }
+        }
+
+        friendMessageHandler = { publicKey, _, _, message ->
+            val timestamp = getDate()
+            contactRepository.setLastMessage(publicKey, timestamp)
+            messageRepository.add(
+                Message(publicKey, message, Sender.Received, Int.MIN_VALUE, timestamp)
+            )
+            notificationHelper.showMessageNotification(contactByPublicKey(publicKey), message)
+        }
+
+        friendNameHandler = { publicKey, newName ->
+            contactRepository.setName(publicKey, newName)
+        }
+
+        fileRecvChunkHandler = { publicKey, fileNumber, position, data ->
+            fileTransferManager.addDataToTransfer(publicKey, fileNumber, position, data)
+        }
+
+        fileRecvHandler = { publicKey, fileNumber, kind, fileSize, filename ->
+            val name = if (kind == FileKind.Avatar.ordinal) publicKey else filename
+            fileTransferManager.add(
+                FileTransfer(publicKey, fileNumber, kind, fileSize, name, outgoing = false)
+            )
+        }
+
+        selfConnectionStatusHandler = { status ->
+            userRepository.updateConnection(tox.publicKey.string(), status)
+        }
+
+        friendTypingHandler = { publicKey, isTyping ->
+            contactRepository.setTyping(publicKey, isTyping)
+        }
+    }
+}

--- a/atox/src/main/java/ltd/evilcorp/atox/tox/ToxStarter.kt
+++ b/atox/src/main/java/ltd/evilcorp/atox/tox/ToxStarter.kt
@@ -14,11 +14,13 @@ private const val TAG = "ToxStarter"
 class ToxStarter @Inject constructor(
     private val saveManager: SaveManager,
     private val userManager: UserManager,
+    private val listenerCallbacks: EventListenerCallbacks,
     private val tox: Tox,
     private val eventListener: ToxEventListener,
     private val context: Context
 ) {
     fun startTox(save: ByteArray? = null): Boolean = try {
+        listenerCallbacks.setUp(eventListener)
         tox.start(SaveOptions(save), eventListener)
         startService()
         true


### PR DESCRIPTION
This is so that we can set up the callbacks to do things that would require ridiculous dependencies, and part of splitting out the Tox stuff into a separate module (#271).

E.g. if the ToxService needed to know our connection status without the ToxEventListener holding a reference to the ToxService, we could now let the ToxService add a callback to it.