### PR TITLE
Add the Bazel output dirs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .externalNativeBuild
 .gradle
 .idea
+bazel-*
 build
 captures
 local.properties


### PR DESCRIPTION
Even if I'm not done with all the BUILD.bazel files, this makes switching between branches less annoying.

Part of #361 