### PR TITLE
Updatable user status

### DIFF
--- a/atox/src/main/kotlin/ui/contactlist/ContactListFragment.kt
+++ b/atox/src/main/kotlin/ui/contactlist/ContactListFragment.kt
@@ -72,11 +72,16 @@ class ContactListFragment : Fragment(), NavigationView.OnNavigationItemSelectedL
                 userIntitialized = true
             }
 
-            toolbar.subtitle = if (user.connectionStatus == ConnectionStatus.None) {
-                getText(R.string.connecting)
-            } else {
+            val connnectionString = if (user.connectionStatus != ConnectionStatus.None) {
                 getText(R.string.connected)
+            } else {
+                getText(R.string.connecting)
             }
+            toolbar.subtitle = getString(
+                R.string.connection_and_status,
+                connnectionString,
+                resources.getStringArray(R.array.user_statuses)[user.status.ordinal]
+            )
         })
 
         navView.setNavigationItemSelectedListener(this@ContactListFragment)

--- a/atox/src/main/kotlin/ui/contactlist/ContactListViewModel.kt
+++ b/atox/src/main/kotlin/ui/contactlist/ContactListViewModel.kt
@@ -12,6 +12,7 @@ import ltd.evilcorp.atox.ToxService
 import ltd.evilcorp.atox.tox.ToxStarter
 import ltd.evilcorp.core.vo.FriendRequest
 import ltd.evilcorp.core.vo.User
+import ltd.evilcorp.core.vo.UserStatus
 import ltd.evilcorp.domain.feature.ContactManager
 import ltd.evilcorp.domain.feature.FriendRequestManager
 import ltd.evilcorp.domain.feature.UserManager
@@ -43,6 +44,7 @@ class ContactListViewModel @Inject constructor(
 
     fun setName(name: String) = userManager.setName(name)
     fun setStatusMessage(statusMessage: String) = userManager.setStatusMessage(statusMessage)
+    fun setStatus(status: UserStatus) = userManager.setStatus(status)
 
     fun acceptFriendRequest(friendRequest: FriendRequest) = friendRequestManager.accept(friendRequest)
     fun rejectFriendRequest(friendRequest: FriendRequest) = friendRequestManager.reject(friendRequest)

--- a/atox/src/main/res/layout/nav_header_contact_list.xml
+++ b/atox/src/main/res/layout/nav_header_contact_list.xml
@@ -11,13 +11,28 @@
         android:paddingRight="@dimen/activity_horizontal_margin"
         android:paddingBottom="@dimen/activity_vertical_margin"
         android:theme="@style/ThemeOverlay.AppCompat.Dark">
-    <ImageView android:id="@+id/profilePhoto"
-            android:layout_width="wrap_content"
+    <androidx.constraintlayout.widget.ConstraintLayout android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:contentDescription="@string/profile_photo_description"
-            android:paddingTop="@dimen/nav_header_vertical_spacing"
-            android:src="@mipmap/ic_launcher_round"
-            app:srcCompat="@mipmap/ic_launcher_round"/>
+            android:orientation="horizontal">
+        <ImageView android:id="@+id/profilePhoto"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/profile_photo_description"
+                android:paddingTop="@dimen/nav_header_vertical_spacing"
+                android:src="@mipmap/ic_launcher_round"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@mipmap/ic_launcher_round"/>
+        <!-- TODO(robinlinden): This looks stupid here. Move it. -->
+        <!-- TODO(robinlinden): Use nice color icons instead of text. -->
+        <Spinner android:id="@+id/statusSelector"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintHorizontal_bias="1"
+                app:layout_constraintLeft_toRightOf="@+id/profilePhoto"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"/>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <TextView android:id="@+id/profileName"
             android:layout_width="match_parent"

--- a/atox/src/main/res/layout/nav_header_contact_list.xml
+++ b/atox/src/main/res/layout/nav_header_contact_list.xml
@@ -11,28 +11,13 @@
         android:paddingRight="@dimen/activity_horizontal_margin"
         android:paddingBottom="@dimen/activity_vertical_margin"
         android:theme="@style/ThemeOverlay.AppCompat.Dark">
-    <androidx.constraintlayout.widget.ConstraintLayout android:layout_width="match_parent"
+    <ImageView android:id="@+id/profilePhoto"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
-        <ImageView android:id="@+id/profilePhoto"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:contentDescription="@string/profile_photo_description"
-                android:paddingTop="@dimen/nav_header_vertical_spacing"
-                android:src="@mipmap/ic_launcher_round"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:srcCompat="@mipmap/ic_launcher_round"/>
-        <!-- TODO(robinlinden): This looks stupid here. Move it. -->
-        <!-- TODO(robinlinden): Use nice color icons instead of text. -->
-        <Spinner android:id="@+id/statusSelector"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:layout_constraintHorizontal_bias="1"
-                app:layout_constraintLeft_toRightOf="@+id/profilePhoto"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"/>
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            android:contentDescription="@string/profile_photo_description"
+            android:paddingTop="@dimen/nav_header_vertical_spacing"
+            android:src="@mipmap/ic_launcher_round"
+            app:srcCompat="@mipmap/ic_launcher_round"/>
 
     <TextView android:id="@+id/profileName"
             android:layout_width="match_parent"
@@ -41,8 +26,27 @@
             android:text="@string/name_default"
             android:textAppearance="@style/TextAppearance.AppCompat.Body1"/>
 
-    <TextView android:id="@+id/profileStatusMessage"
-            android:layout_width="wrap_content"
+    <androidx.constraintlayout.widget.ConstraintLayout android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/status_message_default"/>
+            android:orientation="horizontal">
+        <TextView android:id="@+id/profileStatusMessage"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/status_message_default"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toTopOf="parent"/>
+
+        <ImageButton android:id="@+id/statusSwitcher"
+                android:layout_width="15dp"
+                android:layout_height="15dp"
+                android:background="@null"
+                android:contentDescription="@string/status_switcher"
+                android:src="@drawable/circle"
+                android:tint="@color/statusOffline"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintHorizontal_bias="1"
+                app:layout_constraintLeft_toRightOf="@+id/profileStatusMessage"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toTopOf="parent"/>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </LinearLayout>

--- a/atox/src/main/res/values/strings.xml
+++ b/atox/src/main/res/values/strings.xml
@@ -73,6 +73,7 @@
     <string name="version_display">aTox v%1$s - %2$d</string>
     <string name="send_as_action">Send as action</string>
     <string name="or_import_existing_save">or import an existing Tox save</string>
+    <string name="connection_and_status">%1$s - %2$s</string>
     <string-array name="user_statuses">
         <item>Available</item>
         <item>Away</item>

--- a/atox/src/main/res/values/strings.xml
+++ b/atox/src/main/res/values/strings.xml
@@ -74,6 +74,7 @@
     <string name="send_as_action">Send as action</string>
     <string name="or_import_existing_save">or import an existing Tox save</string>
     <string name="connection_and_status">%1$s - %2$s</string>
+    <string name="status_switcher">Status switcher</string>
     <string-array name="user_statuses">
         <item>Available</item>
         <item>Away</item>

--- a/atox/src/main/res/values/strings.xml
+++ b/atox/src/main/res/values/strings.xml
@@ -73,4 +73,9 @@
     <string name="version_display">aTox v%1$s - %2$d</string>
     <string name="send_as_action">Send as action</string>
     <string name="or_import_existing_save">or import an existing Tox save</string>
+    <string-array name="user_statuses">
+        <item>Available</item>
+        <item>Away</item>
+        <item>Busy</item>
+    </string-array>
 </resources>

--- a/core/src/main/kotlin/db/UserDao.kt
+++ b/core/src/main/kotlin/db/UserDao.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.room.*
 import ltd.evilcorp.core.vo.ConnectionStatus
 import ltd.evilcorp.core.vo.User
+import ltd.evilcorp.core.vo.UserStatus
 
 @Dao
 internal interface UserDao {
@@ -21,6 +22,9 @@ internal interface UserDao {
 
     @Query("UPDATE users SET connection_status = :connectionStatus WHERE public_key == :publicKey")
     fun updateConnection(publicKey: String, connectionStatus: ConnectionStatus)
+
+    @Query("UPDATE users SET status = :status WHERE public_key == :publicKey")
+    fun updateStatus(publicKey: String, status: UserStatus)
 
     @Delete
     fun delete(user: User)

--- a/core/src/main/kotlin/repository/UserRepository.kt
+++ b/core/src/main/kotlin/repository/UserRepository.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import ltd.evilcorp.core.db.UserDao
 import ltd.evilcorp.core.vo.ConnectionStatus
 import ltd.evilcorp.core.vo.User
+import ltd.evilcorp.core.vo.UserStatus
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -31,4 +32,7 @@ class UserRepository @Inject internal constructor(
 
     fun updateConnection(publicKey: String, connectionStatus: ConnectionStatus) =
         userDao.updateConnection(publicKey, connectionStatus)
+
+    fun updateStatus(publicKey: String, status: UserStatus) =
+        userDao.updateStatus(publicKey, status)
 }

--- a/domain/src/main/kotlin/feature/UserManager.kt
+++ b/domain/src/main/kotlin/feature/UserManager.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import ltd.evilcorp.core.repository.UserRepository
 import ltd.evilcorp.core.vo.User
+import ltd.evilcorp.core.vo.UserStatus
 import ltd.evilcorp.domain.tox.PublicKey
 import ltd.evilcorp.domain.tox.Tox
 import javax.inject.Inject
@@ -42,5 +43,10 @@ class UserManager @Inject constructor(
     fun setStatusMessage(statusMessage: String) = launch {
         tox.setStatusMessage(statusMessage)
         userRepository.updateStatusMessage(tox.publicKey.string(), statusMessage)
+    }
+
+    fun setStatus(status: UserStatus) = launch {
+        tox.setStatus(status)
+        userRepository.updateStatus(tox.publicKey.string(), status)
     }
 }

--- a/domain/src/main/kotlin/tox/Tox.kt
+++ b/domain/src/main/kotlin/tox/Tox.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.*
 import ltd.evilcorp.core.repository.ContactRepository
 import ltd.evilcorp.core.vo.Contact
 import ltd.evilcorp.core.vo.MessageType
+import ltd.evilcorp.core.vo.UserStatus
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -151,5 +152,9 @@ class Tox @Inject constructor(
 
     fun setTyping(publicKey: PublicKey, typing: Boolean) = launch {
         tox.setTyping(publicKey, typing)
+    }
+
+    fun setStatus(status: UserStatus) = launch {
+        tox.setStatus(status)
     }
 }

--- a/domain/src/main/kotlin/tox/ToxUtil.kt
+++ b/domain/src/main/kotlin/tox/ToxUtil.kt
@@ -28,6 +28,12 @@ fun SaveOptions.toToxOptions(): ToxOptions = ToxOptions(
     true
 )
 
+fun UserStatus.toToxType(): ToxUserStatus = when(this) {
+    UserStatus.None -> ToxUserStatus.NONE
+    UserStatus.Away -> ToxUserStatus.AWAY
+    UserStatus.Busy -> ToxUserStatus.BUSY
+}
+
 fun MessageType.toToxType(): ToxMessageType = when(this) {
     MessageType.Normal -> ToxMessageType.NORMAL
     MessageType.Action -> ToxMessageType.ACTION

--- a/domain/src/main/kotlin/tox/ToxWrapper.kt
+++ b/domain/src/main/kotlin/tox/ToxWrapper.kt
@@ -5,6 +5,7 @@ import im.tox.tox4j.core.enums.ToxFileControl
 import im.tox.tox4j.core.exceptions.ToxFriendAddException
 import im.tox.tox4j.impl.jni.ToxCoreImpl
 import ltd.evilcorp.core.vo.MessageType
+import ltd.evilcorp.core.vo.UserStatus
 
 private const val TAG = "ToxWrapper"
 
@@ -93,6 +94,10 @@ class ToxWrapper(
         tox.fileControl(contactByKey(publicKey), fileNumber, ToxFileControl.CANCEL)
 
     fun setTyping(publicKey: PublicKey, typing: Boolean) = tox.setTyping(contactByKey(publicKey), typing)
+
+    fun setStatus(status: UserStatus) {
+        tox.status = status.toToxType()
+    }
 
     private fun contactByKey(publicKey: PublicKey): Int = tox.friendByPublicKey(publicKey.bytes())
 }

--- a/domain/src/test/kotlin/tox/ToxUtilTest.kt
+++ b/domain/src/test/kotlin/tox/ToxUtilTest.kt
@@ -53,6 +53,10 @@ class ToxUtilTest {
             assertEquals(it.ordinal, it.toUserStatus().ordinal)
         }
 
+        UserStatus.values().forEach { type ->
+            assertEquals(type, type.toToxType().toUserStatus())
+        }
+
         assertEquals(ToxUserStatus.NONE.ordinal, UserStatus.None.ordinal)
         assertEquals(ToxUserStatus.AWAY.ordinal, UserStatus.Away.ordinal)
         assertEquals(ToxUserStatus.BUSY.ordinal, UserStatus.Busy.ordinal)


### PR DESCRIPTION
New. Prettier, but less obvious:
![busy](https://user-images.githubusercontent.com/8304462/77861894-31e38f80-7218-11ea-9eca-8886493a21c8.png)

![away](https://user-images.githubusercontent.com/8304462/77861919-550e3f00-7218-11ea-9a54-573df69e100f.png)


Old:
![connection and user status](https://user-images.githubusercontent.com/8304462/77824287-e474fe80-7101-11ea-82a1-dd2e49a9836e.png)

![the user status dropdown](https://user-images.githubusercontent.com/8304462/77824297-f656a180-7101-11ea-9f09-d68da81d811f.png)

