### PR TITLE
Make the import Tox save button obvious

### DIFF
--- a/atox/src/main/kotlin/ui/profile/ProfileFragment.kt
+++ b/atox/src/main/kotlin/ui/profile/ProfileFragment.kt
@@ -57,20 +57,13 @@ class ProfileFragment : Fragment() {
             findNavController().popBackStack()
         }
 
-        toolbar.inflateMenu(R.menu.profile_options_menu)
-        toolbar.setOnMenuItemClickListener { item ->
-            when (item.itemId) {
-                R.id.import_tox_save -> {
-                    val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
-                        addCategory(Intent.CATEGORY_OPENABLE)
-                        type = "*/*"
-                    }
-
-                    startActivityForResult(intent, IMPORT)
-                    true
-                }
-                else -> super.onOptionsItemSelected(item)
+        btnImport.setOnClickListener { _ ->
+            val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                addCategory(Intent.CATEGORY_OPENABLE)
+                type = "*/*"
             }
+
+            startActivityForResult(intent, IMPORT)
         }
     }
 

--- a/atox/src/main/res/layout/profile_fragment.xml
+++ b/atox/src/main/res/layout/profile_fragment.xml
@@ -57,5 +57,23 @@
                 android:text="@string/create"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/password"/>
+
+        <TextView android:id="@+id/importLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="@string/or_import_existing_save"
+                android:textSize="20sp"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/btnCreate"
+                app:layout_constraintVertical_chainStyle="packed"/>
+
+        <Button android:id="@+id/btnImport"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/import_tox_save"
+                app:layout_constraintTop_toBottomOf="@+id/importLabel"
+                app:layout_constraintVertical_chainStyle="packed"/>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </LinearLayout>

--- a/atox/src/main/res/menu/profile_options_menu.xml
+++ b/atox/src/main/res/menu/profile_options_menu.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:id="@+id/import_tox_save" android:title="@string/import_tox_save"/>
-</menu>

--- a/atox/src/main/res/values/strings.xml
+++ b/atox/src/main/res/values/strings.xml
@@ -52,7 +52,7 @@
     <string name="clear_history_confirm">Are you sure you want to clear your chat history with
         %1$s?
     </string>
-    <string name="import_tox_save">Import Tox save</string>
+    <string name="import_tox_save">Import</string>
     <string name="import_tox_save_failed">Import failed for some reason</string>
     <string name="export_tox_save">Export Tox save</string>
     <string name="tox_save_exported">Tox save exported</string>
@@ -72,4 +72,5 @@
     </string-array>
     <string name="version_display">aTox v%1$s - %2$d</string>
     <string name="send_as_action">Send as action</string>
+    <string name="or_import_existing_save">or import an existing Tox save</string>
 </resources>


### PR DESCRIPTION
![new profile creation screen](https://user-images.githubusercontent.com/8304462/77828409-8b19c900-711b-11ea-9acd-98b4d7c1fee2.png)

Previously it was hidden under an overflow menu in profile creation and @XaviDCR92 suggested this might be nicer.