### PR TITLE
Lint maintenance

### DIFF
--- a/atox/build.gradle.kts
+++ b/atox/build.gradle.kts
@@ -38,8 +38,7 @@ android {
         freeCompilerArgs = listOf("-XXLanguage:+InlineClasses")
     }
     lintOptions {
-        // TODO(robinlinden): Delete/update invalid packages
-        disable("InvalidPackage", "GoogleAppIndexingWarning", "MissingTranslation")
+        disable("GoogleAppIndexingWarning", "MissingTranslation")
     }
     sourceSets["main"].java.srcDir("src/main/kotlin")
     sourceSets["androidTest"].java.srcDir("src/androidTest/kotlin")

--- a/atox/src/main/kotlin/ui/profile/ProfileFragment.kt
+++ b/atox/src/main/kotlin/ui/profile/ProfileFragment.kt
@@ -57,7 +57,7 @@ class ProfileFragment : Fragment() {
             findNavController().popBackStack()
         }
 
-        btnImport.setOnClickListener { _ ->
+        btnImport.setOnClickListener {
             val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
                 addCategory(Intent.CATEGORY_OPENABLE)
                 type = "*/*"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -74,11 +74,6 @@ object Libraries {
     // 3.6.0 is the last version before API 24 was required.
     const val zxingAndroidEmbedded = "com.journeyapps:zxing-android-embedded:3.6.0"
 
-    const val scalaLibrary = "org.scala-lang:scala-library:2.11.12"
-    const val scalaLogging = "com.typesafe.scala-logging:scala-logging_2.11:3.9.2"
-    const val scalapbRuntime = "com.trueaccord.scalapb:scalapb-runtime_2.11:0.6.7"
-    const val scodecCore = "org.scodec:scodec-core_2.11:1.11.4"
-
     const val leakcanaryAndroid = "com.squareup.leakcanary:leakcanary-android:${Version.leakCanary}"
 
     const val junit = "junit:junit:4.13"

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -42,8 +42,6 @@ android {
     lintOptions {
         isAbortOnError = true
         isWarningsAsErrors = true
-        // TODO(robinlinden): Delete/update invalid packages
-        disable("InvalidPackage")
     }
     sourceSets["main"].java.srcDir("src/main/kotlin")
     sourceSets["test"].java.srcDir("src/test/kotlin")


### PR DESCRIPTION
Remove a few names of packages no longer used, remove unnecessary lamda arrow, and enable the InvalidPackage lint again now that we don't have any invalid packages.