### PR TITLE
Revert Toxcore update

### DIFF
--- a/atox/build.gradle.kts
+++ b/atox/build.gradle.kts
@@ -42,11 +42,6 @@ android {
     }
     sourceSets["main"].java.srcDir("src/main/kotlin")
     sourceSets["androidTest"].java.srcDir("src/androidTest/kotlin")
-    packagingOptions {
-        // Work around scala-compiler and scala-library (via tox4j) trying to place files in the
-        // same place.
-        exclude("rootdoc.txt")
-    }
 }
 
 dependencies {

--- a/atox/build.gradle.kts
+++ b/atox/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "ltd.evilcorp.atox"
         minSdkVersion(AndroidSdk.minVersion)
         targetSdkVersion(AndroidSdk.targetVersion)
-        versionCode = 2
-        versionName = "0.2.0"
+        versionCode = 3
+        versionName = "0.2.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled = true
         vectorDrawables.useSupportLibrary = true

--- a/atox/src/main/kotlin/ui/profile/ProfileFragment.kt
+++ b/atox/src/main/kotlin/ui/profile/ProfileFragment.kt
@@ -57,7 +57,7 @@ class ProfileFragment : Fragment() {
             findNavController().popBackStack()
         }
 
-        btnImport.setOnClickListener {
+        btnImport.setOnClickListener { _ ->
             val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
                 addCategory(Intent.CATEGORY_OPENABLE)
                 type = "*/*"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,9 +2,6 @@ buildscript {
     repositories {
         google()
         jcenter()
-        maven {
-            url = uri("https://dl.bintray.com/toktok/maven")
-        }
     }
     dependencies {
         classpath(BuildPlugin.gradle)
@@ -13,6 +10,7 @@ buildscript {
 }
 
 plugins {
+    id(BuildPlugin.download) version BuildPlugin.downloadVersion
     id(BuildPlugin.ideaExt) version BuildPlugin.ideaExtVersion
 }
 
@@ -20,9 +18,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven {
-            url = uri("https://dl.bintray.com/toktok/maven")
-        }
     }
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -31,6 +31,9 @@ object BuildPlugin {
 
     const val ideaExt = "org.jetbrains.gradle.plugin.idea-ext"
     const val ideaExtVersion = "0.7"
+
+    const val download = "de.undercouch.download"
+    const val downloadVersion = "4.0.4"
 }
 
 object AndroidSdk {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -74,6 +74,11 @@ object Libraries {
     // 3.6.0 is the last version before API 24 was required.
     const val zxingAndroidEmbedded = "com.journeyapps:zxing-android-embedded:3.6.0"
 
+    const val scalaLibrary = "org.scala-lang:scala-library:2.11.12"
+    const val scalaLogging = "com.typesafe.scala-logging:scala-logging_2.11:3.9.2"
+    const val scalapbRuntime = "com.trueaccord.scalapb:scalapb-runtime_2.11:0.6.7"
+    const val scodecCore = "org.scodec:scodec-core_2.11:1.11.4"
+
     const val leakcanaryAndroid = "com.squareup.leakcanary:leakcanary-android:${Version.leakCanary}"
 
     const val junit = "junit:junit:4.13"

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -57,6 +57,8 @@ idea {
 }
 
 dependencies {
+    api(fileTree("libs") { include("*.jar") })
+
     implementation(Libraries.kotlinStdLib)
 
     implementation(project(":core"))
@@ -65,13 +67,43 @@ dependencies {
 
     implementation(Libraries.ktxCoroutinesCore)
 
-    api("org.toktok:tox4j-api_2.11:0.2.3")
-    implementation("org.toktok:tox4j-c_2.11:0.2.3")
+    // For tox4j
+    // TODO(robinlinden): Fix tox4j build so we can update the scala dependencies
+    // noinspection GradleDependency
+    implementation(Libraries.scalaLibrary)
+    implementation(Libraries.scalaLogging)
+    implementation(Libraries.scalapbRuntime)
+    implementation(Libraries.scodecCore)
 
     testImplementation(Libraries.junit)
 }
 
+val files = listOf(
+    "https://build.tox.chat/job/tox4j-api_build_android_multiarch_release/lastSuccessfulBuild/artifact/tox4j-api/target/scala-2.11/tox4j-api_2.11-0.1.2.jar" to "libs/tox4j-api-c.jar",
+    "https://build.tox.chat/job/tox4j_build_android_arm64_release/lastSuccessfulBuild/artifact/artifacts/tox4j-c_2.11-0.1.2-SNAPSHOT.jar" to "libs/tox4j-c.jar",
+    "https://build.tox.chat/job/tox4j_build_android_armel_release/lastSuccessfulBuild/artifact/artifacts/libtox4j-c.so" to "src/main/jniLibs/armeabi-v7a/libtox4j-c.so",
+    "https://build.tox.chat/job/tox4j_build_android_armel_release/lastSuccessfulBuild/artifact/artifacts/libtox4j-c.so" to "src/main/jniLibs/armeabi/libtox4j-c.so",
+    "https://build.tox.chat/job/tox4j_build_android_x86_release/lastSuccessfulBuild/artifact/artifacts/libtox4j-c.so" to "src/main/jniLibs/x86/libtox4j-c.so",
+    "https://build.tox.chat/job/tox4j_build_android_arm64_release/lastSuccessfulBuild/artifact/artifacts/libtox4j-c.so" to "src/main/jniLibs/arm64-v8a/libtox4j-c.so",
+    "https://build.tox.chat/job/tox4j_build_android_x86-64_release/lastSuccessfulBuild/artifact/artifacts/libtox4j-c.so" to "src/main/jniLibs/x86_64/libtox4j-c.so"
+)
+
+val fetchTask = task<DefaultTask>("fetchTox4j")
+
+files.forEach { (url, dst) ->
+    val taskName = "fetch_${dst.replace("/", "_")}"
+    task<de.undercouch.gradle.tasks.download.Download>(taskName) {
+        src(url)
+        dest(dst)
+        overwrite(false)
+    }
+
+    fetchTask.dependsOn(taskName)
+}
+
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    dependsOn(fetchTask)
+
     // newSingleThreadContext
     kotlinOptions.freeCompilerArgs += listOf("-Xuse-experimental=kotlinx.coroutines.ObsoleteCoroutinesApi")
 }


### PR DESCRIPTION
The Toxcore update built on you having built .so files and manually placed them in the correct folders, so it was just luck that things worked when I built the release. I'll redo the lift once I've worked out a nice way to do it.