### PR TITLE
Disable the InvalidPackage lint

### DIFF
--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -42,6 +42,7 @@ android {
     lintOptions {
         isAbortOnError = true
         isWarningsAsErrors = true
+        disable("InvalidPackage")
     }
     sourceSets["main"].java.srcDir("src/main/kotlin")
     sourceSets["test"].java.srcDir("src/test/kotlin")


### PR DESCRIPTION
Travis has been having issues and hasn't always been running for PRs for
a few weeks now, so I missed disabling it when I had to revert to the
old version of tox4j again.