### PR TITLE
Make sure that tox4j is always included

### DIFF
--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.android.build.gradle.internal.tasks.factory.dependsOn
 import org.gradle.plugins.ide.idea.model.IdeaModule
 import org.jetbrains.gradle.ext.ModuleSettings
 import org.jetbrains.gradle.ext.PackagePrefixContainer
@@ -96,6 +97,8 @@ tasks.register("fixPaths") {
         }
     }
 }
+
+tasks.named("preBuild") { dependsOn("fixPaths") }
 
 dependencies {
     implementation(project(":core"))


### PR DESCRIPTION
Android Studio always runs the task, but building with `./gradlew assemble` from the cmdline never included it for some reason.