### PR TITLE
File transfer improvements

### DIFF
--- a/atox/src/main/kotlin/ui/chat/ChatAdapter.kt
+++ b/atox/src/main/kotlin/ui/chat/ChatAdapter.kt
@@ -17,6 +17,7 @@ import android.widget.TextView
 import com.squareup.picasso.Picasso
 import java.net.URLConnection
 import java.text.DateFormat
+import java.util.Locale
 import kotlin.math.roundToInt
 import ltd.evilcorp.atox.R
 import ltd.evilcorp.core.vo.FileTransfer
@@ -70,6 +71,7 @@ private class FileTransferViewHolder(row: View) {
     val container = row.findViewById(R.id.fileTransferContainer) as LinearLayout
     val fileName = row.findViewById(R.id.fileName) as TextView
     val progress = row.findViewById(R.id.progress) as ProgressBar
+    val state = row.findViewById(R.id.state) as TextView
     val timestamp = row.findViewById(R.id.timestamp) as TextView
     val acceptLayout = row.findViewById(R.id.acceptLayout) as View
     val accept = row.findViewById(R.id.accept) as Button
@@ -192,10 +194,12 @@ class ChatAdapter(
                     vh.completedLayout.visibility = View.GONE
                 }
 
+                vh.state.visibility = View.GONE
                 if (fileTransfer.isRejected() || fileTransfer.isComplete()) {
                     vh.acceptLayout.visibility = View.GONE
                     vh.cancelLayout.visibility = View.GONE
-                    vh.progress.visibility = if (fileTransfer.isRejected()) View.GONE else View.VISIBLE
+                    vh.progress.visibility = View.GONE
+                    vh.state.visibility = View.VISIBLE
                 } else if (!fileTransfer.isStarted()) {
                     if (fileTransfer.outgoing) {
                         vh.acceptLayout.visibility = View.GONE
@@ -215,6 +219,9 @@ class ChatAdapter(
                 vh.fileName.text = fileTransfer.fileName
                 vh.progress.max = fileTransfer.fileSize.toInt()
                 vh.progress.progress = fileTransfer.progress.toInt()
+                // TODO(robinlinden): paused, but that requires a database update and a release is overdue.
+                val stateId = if (fileTransfer.isRejected()) R.string.cancelled else R.string.completed
+                vh.state.text = resources.getString(stateId).toLowerCase(Locale.getDefault())
                 vh.timestamp.text = timeFormatter.format(message.timestamp)
 
                 vh.timestamp.visibility = if (position == messages.lastIndex) {

--- a/atox/src/main/res/layout/chat_filetransfer.xml
+++ b/atox/src/main/res/layout/chat_filetransfer.xml
@@ -25,6 +25,10 @@
                     style="?android:attr/progressBarStyleHorizontal"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"/>
+            <TextView android:id="@+id/state"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:visibility="gone"/>
             <LinearLayout android:id="@+id/acceptLayout"
                     style="?buttonBarStyle"
                     android:layout_width="wrap_content"

--- a/atox/src/main/res/values/strings.xml
+++ b/atox/src/main/res/values/strings.xml
@@ -104,4 +104,6 @@
     <string name="attach_file">Attach file</string>
     <string name="delete">Delete</string>
     <string name="notification_file_transfer">Incoming file transfer \"%1$s\"</string>
+    <string name="cancelled">Cancelled</string>
+    <string name="completed">Completed</string>
 </resources>

--- a/domain/src/main/kotlin/feature/FileTransferManager.kt
+++ b/domain/src/main/kotlin/feature/FileTransferManager.kt
@@ -154,8 +154,8 @@ class FileTransferManager @Inject constructor(
 
     fun reject(ft: FileTransfer) {
         Log.i(TAG, "Reject ${ft.fileNumber} for ${ft.publicKey.take(8)}")
-        setProgress(ft, FtRejected)
         fileTransfers.remove(ft)
+        setProgress(ft, FtRejected)
         tox.stopFileTransfer(PublicKey(ft.publicKey), ft.fileNumber)
         clearTmpFile(ft)
     }
@@ -168,13 +168,10 @@ class FileTransferManager @Inject constructor(
     }
 
     private fun setProgress(ft: FileTransfer, progress: Long) {
-        try {
-            fileTransfers[fileTransfers.indexOf(ft)].progress = progress
-            if (ft.fileKind == FileKind.Data.ordinal) {
-                fileTransferRepository.updateProgress(ft.id, progress)
-            }
-        } catch (e: ArrayIndexOutOfBoundsException) {
-            Log.e(TAG, "Tried setting the progress for an unknown ft ${ft.publicKey.take(8)} ${ft.fileNumber}")
+        val id = fileTransfers.indexOf(ft)
+        fileTransfers.elementAtOrNull(id)?.progress = progress
+        if (ft.fileKind == FileKind.Data.ordinal) {
+            fileTransferRepository.updateProgress(ft.id, progress)
         }
     }
 


### PR DESCRIPTION
* Make sure the file transfer cache is cleared when it should be.
* Add a status text displaying when a ft is cancelled/completed.
* Fix fts ocasionally getting stuck in a state where the UI refuses to accept that they're cancelled.

A status text indicating pause will be added after 0.5.0. The file transfer cache thing will be rewritten to allow for resumable file transfers, also after 0.5.0.

**Big** thanks to @JFreegman for helping test and debug the file transfer code.