### PR TITLE
Fix status indicator incorrectly displaying offline on old Android

### DIFF
--- a/atox/src/main/res/layout/profile_image_layout.xml
+++ b/atox/src/main/res/layout/profile_image_layout.xml
@@ -23,6 +23,5 @@
             android:translationZ="10dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            app:tint="@color/statusOffline"
             tools:targetApi="LOLLIPOP" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
It seems as if you go to e.g. the ChatFragment, then the
ContactProfileFragment, then back to the ChatFragment, Android (API <=
21 at least) will use the tint set in XML instead of the colour set by
the contact status callback.