### PR TITLE
Streamline file transfer handling

### DIFF
--- a/atox/src/main/AndroidManifest.xml
+++ b/atox/src/main/AndroidManifest.xml
@@ -26,6 +26,16 @@
             </intent-filter>
         </receiver>
 
+        <provider
+                android:name="androidx.core.content.FileProvider"
+                android:authorities="ltd.evilcorp.fileprovider"
+                android:exported="false"
+                android:grantUriPermissions="true">
+            <meta-data
+                    android:name="android.support.FILE_PROVIDER_PATHS"
+                    android:resource="@xml/file_paths" />
+        </provider>
+
         <activity android:name=".MainActivity">
             <nav-graph android:value="@navigation/nav_graph"/>
             <intent-filter>

--- a/atox/src/main/res/menu/ft_message_context_menu.xml
+++ b/atox/src/main/res/menu/ft_message_context_menu.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:id="@+id/delete" android:title="@string/delete"/>
+    <item android:id="@+id/export" android:title="@string/save_as"/>
 </menu>

--- a/atox/src/main/res/values/strings.xml
+++ b/atox/src/main/res/values/strings.xml
@@ -106,4 +106,7 @@
     <string name="notification_file_transfer">Incoming file transfer \"%1$s\"</string>
     <string name="cancelled">Cancelled</string>
     <string name="completed">Completed</string>
+    <string name="save_as">Save as…</string>
+    <string name="export_file_success">File exported</string>
+    <string name="export_file_failure">Something went wrong exporting that. Pre-0.5.1 transfers were exported by default.</string>
 </resources>

--- a/atox/src/main/res/xml/file_paths.xml
+++ b/atox/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <files-path name="file_transfers" path="ft/"/>
+</paths>

--- a/core/src/main/kotlin/db/FileTransferDao.kt
+++ b/core/src/main/kotlin/db/FileTransferDao.kt
@@ -19,6 +19,9 @@ internal interface FileTransferDao {
     @Query("SELECT * FROM file_transfers WHERE public_key == :publicKey")
     fun load(publicKey: String): Flow<List<FileTransfer>>
 
+    @Query("SELECT * FROM file_transfers WHERE id == :id")
+    fun load(id: Int): Flow<FileTransfer>
+
     @Query("UPDATE file_transfers SET progress = :progress WHERE id == :id AND progress != :rejected")
     fun updateProgress(id: Int, progress: Long, rejected: Long = FtRejected)
 

--- a/core/src/main/kotlin/repository/FileTransferRepository.kt
+++ b/core/src/main/kotlin/repository/FileTransferRepository.kt
@@ -19,6 +19,9 @@ class FileTransferRepository @Inject internal constructor(
     fun get(publicKey: String): Flow<List<FileTransfer>> =
         dao.load(publicKey)
 
+    fun get(id: Int): Flow<FileTransfer> =
+        dao.load(id)
+
     fun setDestination(id: Int, destination: String) =
         dao.setDestination(id, destination)
 


### PR DESCRIPTION
Now, instead of prompting the user for a storage location before
accepting, the file transfer is accepted into an internal area, and an
option to allow the user to export the file to a user-provided area was
added.