### PR TITLE
Fix getting stuck offline when offline for a long time

### DIFF
--- a/domain/src/main/kotlin/tox/Tox.kt
+++ b/domain/src/main/kotlin/tox/Tox.kt
@@ -31,9 +31,9 @@ class Tox @Inject constructor(
     val publicKey: PublicKey by lazy { tox.getPublicKey() }
 
     var started = false
+    var isBootstrapNeeded = true
 
     private var running = false
-    private var isBootstrapNeeded = true
 
     private lateinit var tox: ToxWrapper
 


### PR DESCRIPTION
This can be worked around by restarting aTox or just toggling UDP/TCP.

The 60-second timeout was chosen arbitrarily and is the only value I
tested.