### PR TITLE
Misc cleanup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,10 @@
 on: [push, pull_request]
 jobs:
-  android-test:
+  gradle-android-test:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: android test
+    - name: Test
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 29
@@ -14,14 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: actions/setup-java@v1
       with:
         java-version: 1.8
     - name: ktlint
       run: ./gradlew ktlint
 
-  build:
+  gradle:
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 6
@@ -32,11 +31,10 @@ jobs:
         - windows-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Setup JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: Building with Gradle
+    - name: Build and test
       run: ./gradlew build
 
   bazel:
@@ -49,11 +47,11 @@ jobs:
           echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/$NDK_VERSION" >> $GITHUB_ENV
       env:
         NDK_VERSION: 21.3.6528147
-    - name: Set up Bazelisk
+    - name: Install
       run: wget https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 --output-document=bazelisk
-    - name: Build with Bazel
+    - name: Build
       run: bazelisk build //...
-    - name: Test with Bazel
+    - name: Test
       run: bazelisk test //...
 
   buildifier:

--- a/core/src/androidTest/kotlin/db/DatabaseMigrationTest.kt
+++ b/core/src/androidTest/kotlin/db/DatabaseMigrationTest.kt
@@ -192,8 +192,7 @@ class DatabaseMigrationTest {
 
         helper.runMigrationsAndValidate(TEST_DB, 4, true, MIGRATION_3_4).use { db ->
             // The table is nuked during the migration because it was useless before.
-            // TODO(robinlinden): Wrong table. :(
-            assertEquals(db.query("SELECT * FROM messages").count, 0)
+            assertEquals(db.query("SELECT * FROM file_transfers").count, 0)
         }
     }
 

--- a/core/src/main/kotlin/db/Migration.kt
+++ b/core/src/main/kotlin/db/Migration.kt
@@ -19,16 +19,17 @@ val MIGRATION_3_4 = object : Migration(3, 4) {
     override fun migrate(db: SupportSQLiteDatabase) {
         db.execSQL("DROP TABLE IF EXISTS 'file_transfers'")
         db.execSQL(
-            "CREATE TABLE IF NOT EXISTS 'file_transfers'" +
-                "('id' INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL," +
-                "'public_key' TEXT NOT NULL," +
-                "'file_number' INTEGER NOT NULL," +
-                "'file_kind' INTEGER NOT NULL," +
-                "'file_size' INTEGER NOT NULL," +
-                "'file_name' TEXT NOT NULL," +
-                "'destination' TEXT NOT NULL," +
-                "'outgoing' INTEGER NOT NULL," +
-                "'progress' INTEGER NOT NULL)"
+            """CREATE TABLE IF NOT EXISTS 'file_transfers' (
+                'id' INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                'public_key' TEXT NOT NULL,
+                'file_number' INTEGER NOT NULL,
+                'file_kind' INTEGER NOT NULL,
+                'file_size' INTEGER NOT NULL,
+                'file_name' TEXT NOT NULL,
+                'destination' TEXT NOT NULL,
+                'outgoing' INTEGER NOT NULL,
+                'progress' INTEGER NOT NULL)
+            """.trimIndent()
         )
     }
 }


### PR DESCRIPTION
* Port SQL statements to """raw string literals"""
* Use the database with .use-autoclose magic
* Fix a test testing the wrong table
* Rename things in the GitHub Actions CI to feel better now that there are multiple build systems
* Make common test data shared instead of copying it into each test