### PR TITLE
Run all Android tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 29
-        script: ./gradlew connectedCheck -x :atox:connectedAndroidTest -x :domain:connectedAndroidTest
+        script: ./gradlew connectedCheck
 
   ktlint:
     runs-on: ubuntu-latest

--- a/domain/src/androidTest/kotlin/tox/ToxTest.kt
+++ b/domain/src/androidTest/kotlin/tox/ToxTest.kt
@@ -12,7 +12,7 @@ class ToxTest {
     fun quitting_does_not_crash() {
         for (i in 1..10) {
             val tox = Tox(mockk(relaxUnitFun = true), mockk(relaxUnitFun = true))
-            tox.start(SaveOptions(null, false), ToxEventListener(), ToxAvEventListener())
+            tox.start(SaveOptions(null, false, ProxyType.None, "", 0), ToxEventListener(), ToxAvEventListener())
             sleep(25)
             tox.stop()
         }


### PR DESCRIPTION
All tests that pulled in tox4j used to be disabled as it contains broken dependency specifications and this caused junit to crash. Seems like junit is more tolerant of that these days, so here we go.