### PR TITLE
Add scripts for building aTox w/ deps from source

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,3 +69,28 @@ jobs:
           sudo chmod +x buildifier
     - name: Check
       run: ./buildifier --lint=warn --warnings=all -mode diff WORKSPACE $(find . -type f -iname BUILD.*)
+
+  gradle-from-source:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Install tox4j dependencies
+      run: sudo apt install yasm
+    - name: Disallow fetching tox4j
+      run: sed -i '/dl.bintray.com\/toktok\/maven/d' build.gradle.kts
+    - name: Fix tox4j dependency versions
+      run: |
+        sed -i 's/\$oldVersion/\$version/' buildSrc/src/main/kotlin/Dependencies.kt
+        sed -i 's/tox4j-c_arm-linux-androideabi/tox4j-c_armv7a-linux-androideabi/' buildSrc/src/main/kotlin/Dependencies.kt
+    - name: Build tox4j
+      run: |
+        ./scripts/build-host -j$(nproc || sysctl -n hw.ncpu)
+        ./scripts/build-aarch64-linux-android -j$(nproc || sysctl -n hw.ncpu) release
+        ./scripts/build-arm-linux-androideabi -j$(nproc || sysctl -n hw.ncpu) release
+        ./scripts/build-i686-linux-android -j$(nproc || sysctl -n hw.ncpu) release
+        ./scripts/build-x86_64-linux-android -j$(nproc || sysctl -n hw.ncpu) release
+    - name: Build aTox
+      run: ./gradlew build

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ bazel-*
 build
 captures
 local.properties
+
+# gradle-from-source build
+_build
+_git
+_install

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,9 +8,7 @@ buildscript {
         mavenLocal()
         google()
         jcenter()
-        maven {
-            url = uri("https://dl.bintray.com/toktok/maven")
-        }
+         maven { url = uri("https://dl.bintray.com/toktok/maven") }
     }
     dependencies {
         classpath(BuildPlugin.gradle)
@@ -24,9 +22,7 @@ allprojects {
         mavenLocal()
         google()
         jcenter()
-        maven {
-            url = uri("https://dl.bintray.com/toktok/maven")
-        }
+         maven { url = uri("https://dl.bintray.com/toktok/maven") }
     }
 }
 

--- a/scripts/Darwin.mk
+++ b/scripts/Darwin.mk
@@ -1,0 +1,1 @@
+DLLEXT := .dylib

--- a/scripts/Linux.mk
+++ b/scripts/Linux.mk
@@ -1,0 +1,4 @@
+DLLEXT := .so
+
+export CFLAGS	+= -fPIC
+export CXXFLAGS	+= -fPIC

--- a/scripts/android.mk
+++ b/scripts/android.mk
@@ -1,0 +1,57 @@
+NDK_HOME	:= $(SRCDIR)/$(NDK_DIR)
+
+DLLEXT		:= .so
+TOOLCHAIN	:= $(NDK_HOME)/toolchains/llvm/prebuilt/linux-x86_64
+SYSROOT		:= $(TOOLCHAIN)/sysroot
+PREFIX		:= $(DESTDIR)/$(TARGET)
+TOOLCHAIN_FILE	:= $(SRCDIR)/$(TARGET).cmake
+PROTOC		:= $(DESTDIR)/host/bin/protoc
+
+export CC		:= $(TOOLCHAIN)/bin/$(TARGET)$(NDK_API)-clang
+export CXX		:= $(TOOLCHAIN)/bin/$(TARGET)$(NDK_API)-clang++
+export LDFLAGS		:= -static-libstdc++ -llog
+export PKG_CONFIG_LIBDIR:= $(PREFIX)/lib/pkgconfig
+export PKG_CONFIG_PATH	:= $(PREFIX)/lib/pkgconfig
+export PATH		:= $(TOOLCHAIN)/bin:$(PATH)
+export TOX4J_PLATFORM	:= $(TARGET)
+
+protobuf_CONFIGURE	:= --prefix=$(PREFIX) --host=$(TARGET) --with-sysroot=$(SYSROOT) --disable-shared --with-protoc=$(PROTOC)
+libsodium_CONFIGURE	:= --prefix=$(PREFIX) --host=$(TARGET) --with-sysroot=$(SYSROOT) --disable-shared
+opus_CONFIGURE		:= --prefix=$(PREFIX) --host=$(TARGET) --with-sysroot=$(SYSROOT) --disable-shared
+libvpx_CONFIGURE	:= --prefix=$(PREFIX) --sdk-path=$(NDK_HOME) --libc=$(SYSROOT) --target=$(VPX_ARCH) --disable-examples --disable-unit-tests --enable-pic
+toxcore_CONFIGURE	:= -DCMAKE_INSTALL_PREFIX:PATH=$(PREFIX) -DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE) -DANDROID_CPU_FEATURES=$(NDK_HOME)/sources/android/cpufeatures/cpu-features.c -DENABLE_STATIC=ON -DENABLE_SHARED=OFF
+tox4j_CONFIGURE		:= -DCMAKE_INSTALL_PREFIX:PATH=$(PREFIX) -DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE) -DANDROID_CPU_FEATURES=$(NDK_HOME)/sources/android/cpufeatures/cpu-features.c
+
+build: $(PREFIX)/tox4j.stamp $(foreach i,jvm-macros jvm-toxcore-api tox4j-c,$(DESTDIR)/$i.stamp)
+
+test: build
+	@echo "No tests for Android builds"
+
+$(NDK_HOME):
+	@$(PRE_RULE)
+	@mkdir -p $(@D)
+	test -f $(NDK_PACKAGE) || curl -s $(NDK_URL) -o $(NDK_PACKAGE)
+	7z x $(NDK_PACKAGE) -o$(SRCDIR) > /dev/null
+	@$(POST_RULE)
+
+$(TOOLCHAIN_FILE): $(NDK_HOME) scripts/android.mk
+	@$(PRE_RULE)
+	mkdir -p $(TOOLCHAIN)/bin
+	ln -f $(CC) $(TOOLCHAIN)/bin/$(VPX_TARGET)-gcc
+	ln -f $(CXX) $(TOOLCHAIN)/bin/$(VPX_TARGET)-g++
+	mkdir -p $(@D)
+	echo 'set(CMAKE_SYSTEM_NAME Linux)' > $@
+	echo >> $@
+	echo 'set(CMAKE_SYSROOT $(SYSROOT))' >> $@
+	echo >> $@
+	echo 'set(CMAKE_C_COMPILER $(TOOLCHAIN)/bin/$(VPX_TARGET)-gcc)' >> $@
+	echo 'set(CMAKE_CXX_COMPILER $(TOOLCHAIN)/bin/$(VPX_TARGET)-g++)' >> $@
+	echo >> $@
+	echo 'set(CMAKE_FIND_ROOT_PATH $(PREFIX))' >> $@
+	echo 'set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)' >> $@
+	echo 'set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)' >> $@
+	echo 'set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)' >> $@
+	echo 'set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)' >> $@
+	@$(POST_RULE)
+
+include scripts/release.mk

--- a/scripts/build-aarch64-linux-android
+++ b/scripts/build-aarch64-linux-android
@@ -1,0 +1,13 @@
+#!/usr/bin/make -f
+
+TARGET := aarch64-linux-android
+
+include scripts/common.mk
+
+NDK_API := 21
+NDK_ARCH := arm64
+VPX_ARCH := arm64-android-gcc
+VPX_TARGET := $(TARGET)
+
+include scripts/android.mk
+include scripts/dependencies.mk

--- a/scripts/build-arm-linux-androideabi
+++ b/scripts/build-arm-linux-androideabi
@@ -1,0 +1,13 @@
+#!/usr/bin/make -f
+
+TARGET := armv7a-linux-androideabi
+
+include scripts/common.mk
+
+NDK_API := 16
+NDK_ARCH := arm
+VPX_ARCH := armv7-android-gcc
+VPX_TARGET := arm-linux-androideabi
+
+include scripts/android.mk
+include scripts/dependencies.mk

--- a/scripts/build-host
+++ b/scripts/build-host
@@ -1,0 +1,54 @@
+#!/usr/bin/make -f
+
+TARGET := host
+
+include scripts/common.mk
+include scripts/$(shell uname -s).mk
+
+TOOLCHAIN	:= $(DESTDIR)/$(TARGET)
+TOOLCHAIN_FILE	:= $(TOOLCHAIN)/.stamp
+PREFIX		:= $(TOOLCHAIN)
+
+export CC		:= $(shell which clang || which gcc)
+export CXX		:= $(shell which clang++ || which g++)
+export PKG_CONFIG_PATH	:= $(PREFIX)/lib/pkgconfig
+export TOX4J_PLATFORM	:= $(shell perl -e 'print $$^O')-$(shell uname -m)
+
+build: $(PREFIX)/tox4j.stamp $(foreach i,jvm-macros jvm-toxcore-api tox4j-c,$(DESTDIR)/$i.stamp)
+
+test: build
+	$(MAKE) -C _build/$(TARGET)/tox4j test
+	$(MAKE) -f scripts/build-host regenerate
+	git diff --exit-code
+	sbt -Djava.library.path=$(PREFIX)/lib "coverage" "test" "coverageReport"
+
+cpp/src/ToxAv/generated/im_tox_tox4j_impl_jni_ToxAvJni.h: build
+	javah -cp target/scala-2.11/classes im.tox.tox4j.impl.jni.ToxAvJni
+	mv $(@F) $@
+
+cpp/src/ToxCore/generated/im_tox_tox4j_impl_jni_ToxCoreJni.h: build
+	javah -cp target/scala-2.11/classes im.tox.tox4j.impl.jni.ToxCoreJni
+	mv $(@F) $@
+
+cpp/src/ToxCrypto/generated/im_tox_tox4j_impl_jni_ToxCryptoJni.h: build
+	javah -cp target/scala-2.11/classes im.tox.tox4j.impl.jni.ToxCryptoJni
+	mv $(@F) $@
+
+%.run: ; $*
+regenerate: $(foreach i,$(wildcard bin/Jni*),$i.run) $(wildcard cpp/src/*/generated/*.h)
+
+protobuf_CONFIGURE	:= --prefix=$(PREFIX) --disable-shared
+libsodium_CONFIGURE	:= --prefix=$(PREFIX) --disable-shared
+opus_CONFIGURE		:= --prefix=$(PREFIX) --disable-shared
+libvpx_CONFIGURE	:= --prefix=$(PREFIX) --disable-examples --disable-unit-tests --enable-pic
+toxcore_CONFIGURE	:= -DCMAKE_INSTALL_PREFIX:PATH=$(PREFIX) -DENABLE_STATIC=ON -DENABLE_SHARED=OFF
+tox4j_CONFIGURE		:= -DCMAKE_INSTALL_PREFIX:PATH=$(PREFIX)
+
+$(TOOLCHAIN):
+	mkdir -p $@
+
+$(TOOLCHAIN_FILE): $(TOOLCHAIN)
+	touch $@
+
+include scripts/release.mk
+include scripts/dependencies.mk

--- a/scripts/build-i686-linux-android
+++ b/scripts/build-i686-linux-android
@@ -1,0 +1,13 @@
+#!/usr/bin/make -f
+
+TARGET := i686-linux-android
+
+include scripts/common.mk
+
+NDK_API := 16
+NDK_ARCH := x86
+VPX_ARCH := x86-android-gcc
+VPX_TARGET := $(TARGET)
+
+include scripts/android.mk
+include scripts/dependencies.mk

--- a/scripts/build-x86_64-linux-android
+++ b/scripts/build-x86_64-linux-android
@@ -1,0 +1,13 @@
+#!/usr/bin/make -f
+
+TARGET := x86_64-linux-android
+
+include scripts/common.mk
+
+NDK_API := 21
+NDK_ARCH := x86_64
+VPX_ARCH := x86_64-android-gcc
+VPX_TARGET := $(TARGET)
+
+include scripts/android.mk
+include scripts/dependencies.mk

--- a/scripts/common.mk
+++ b/scripts/common.mk
@@ -1,0 +1,22 @@
+SRCDIR			:= $(CURDIR)/_git
+DESTDIR			:= $(CURDIR)/_install
+BUILDDIR		:= $(CURDIR)/_build/$(TARGET)
+
+export CFLAGS		:= -O3 -pipe
+export CXXFLAGS		:= -O3 -pipe
+export LDFLAGS		:=
+
+export PATH		:= $(DESTDIR)/host/bin:$(PATH)
+
+# Android NDK
+NDK_DIR		:= android-ndk-r21
+NDK_PACKAGE	:= $(NDK_DIR)-$(shell perl -e 'print $$^O')-x86_64.zip
+NDK_URL		:= http://dl.google.com/android/repository/$(NDK_PACKAGE)
+
+NDK_COMMON_FILES :=						\
+	sources/android/cpufeatures				\
+	toolchains/llvm/prebuilt/linux-x86_64/bin/clang		\
+	toolchains/llvm/prebuilt/linux-x86_64/bin/clang++	\
+	toolchains/llvm/prebuilt/linux-x86_64/lib/lib64		\
+	toolchains/llvm/prebuilt/linux-x86_64/lib64		\
+	toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include

--- a/scripts/dependencies.mk
+++ b/scripts/dependencies.mk
@@ -1,0 +1,133 @@
+PRE_RULE = (echo "=== Building $@ ==="; ls -ld $@; true) && ls -ld $+
+POST_RULE = ls -ld $@
+
+#############################################################################
+# jvm-macros
+
+# HEAD as of 2021-01-03
+$(SRCDIR)/jvm-macros:
+	git clone https://github.com/toktok/jvm-macros $@
+	cd $@ && git checkout f22e243
+
+$(DESTDIR)/jvm-macros.stamp: $(SRCDIR)/jvm-macros
+	@$(PRE_RULE)
+	cd $< && sbt publishM2
+	mkdir -p $(@D) && touch $@
+	@$(POST_RULE)
+
+#############################################################################
+# jvm-toxcore-api
+
+# HEAD as of 2021-01-03
+$(SRCDIR)/jvm-toxcore-api:
+	git clone https://github.com/toktok/jvm-toxcore-api $@
+	cd $@ && git checkout adb8355
+
+$(DESTDIR)/jvm-toxcore-api.stamp: $(SRCDIR)/jvm-toxcore-api
+	@$(PRE_RULE)
+	cd $< && sbt publishM2
+	mkdir -p $(@D) && touch $@
+	@$(POST_RULE)
+
+#############################################################################
+# tox4j
+
+# HEAD as of 2021-01-03
+$(SRCDIR)/tox4j:
+	git clone https://github.com/toktok/jvm-toxcore-c $@
+	cd $@ && git checkout 50d9a6b
+
+$(BUILDDIR)/tox4j/Makefile: $(SRCDIR)/tox4j $(TOOLCHAIN_FILE) $(foreach i,protobuf toxcore,$(PREFIX)/$i.stamp)
+	@$(PRE_RULE)
+	mkdir -p $(@D)
+	cd $(@D) && cmake $</cpp $($(notdir $(@D))_CONFIGURE)
+	@$(POST_RULE)
+
+$(PREFIX)/tox4j.stamp: $(BUILDDIR)/tox4j/Makefile
+	@$(PRE_RULE)
+	$(MAKE) -C $(<D) install
+	mkdir -p $(@D) && touch $@
+	@$(POST_RULE)
+
+$(DESTDIR)/tox4j-c.stamp: $(SRCDIR)/tox4j
+	@$(PRE_RULE)
+	cd $< && sbt publishM2
+	mkdir -p $(@D) && touch $@
+	@$(POST_RULE)
+
+#############################################################################
+# protobuf
+
+$(SRCDIR)/protobuf:
+	git clone --depth=1 --branch=v3.11.1 https://github.com/google/protobuf $@
+
+$(PREFIX)/protobuf.stamp: $(SRCDIR)/protobuf $(TOOLCHAIN_FILE) $(PROTOC)
+	@$(PRE_RULE)
+	cd $< && autoreconf -fi
+	mkdir -p $(BUILDDIR)/$(notdir $<)
+	cd $(BUILDDIR)/$(notdir $<) && $(SRCDIR)/$(notdir $<)/configure $($(notdir $<)_CONFIGURE)
+	$(MAKE) -C $(BUILDDIR)/$(notdir $<) install V=0
+	mkdir -p $(@D) && touch $@
+	@$(POST_RULE)
+
+#############################################################################
+# toxcore
+
+$(SRCDIR)/toxcore:
+	git clone --depth=1 --branch=v0.2.12 https://github.com/TokTok/c-toxcore $@;
+
+$(PREFIX)/toxcore.stamp: $(foreach f,$(shell cd $(SRCDIR)/toxcore && git ls-files),$(SRCDIR)/toxcore/$f)
+$(PREFIX)/toxcore.stamp: $(SRCDIR)/toxcore $(TOOLCHAIN_FILE) $(foreach i,libsodium opus libvpx,$(PREFIX)/$i.stamp)
+	@$(PRE_RULE)
+	mkdir -p $(BUILDDIR)/$(notdir $<)
+	cd $(BUILDDIR)/$(notdir $<) && cmake $(SRCDIR)/$(notdir $<) $($(notdir $<)_CONFIGURE) -DMUST_BUILD_TOXAV=ON -DBOOTSTRAP_DAEMON=OFF
+	$(MAKE) -C $(BUILDDIR)/$(notdir $<) install
+	mkdir -p $(@D) && touch $@
+	@$(POST_RULE)
+
+#############################################################################
+# libsodium
+
+$(SRCDIR)/libsodium:
+	git clone --depth=1 --branch=1.0.18 https://github.com/jedisct1/libsodium $@
+
+$(PREFIX)/libsodium.stamp: $(SRCDIR)/libsodium $(TOOLCHAIN_FILE)
+	@$(PRE_RULE)
+	cd $< && autoreconf -fi
+	mkdir -p $(BUILDDIR)/$(notdir $<)
+	cd $(BUILDDIR)/$(notdir $<) && $(SRCDIR)/$(notdir $<)/configure $($(notdir $<)_CONFIGURE)
+	$(MAKE) -C $(BUILDDIR)/$(notdir $<) install V=0
+	mkdir -p $(@D) && touch $@
+	@$(POST_RULE)
+
+#############################################################################
+# opus
+
+# HEAD as of 2021-01-03
+$(SRCDIR)/opus:
+	git clone --depth=1 https://github.com/xiph/opus $@
+	cd $@ && git checkout 794392e
+
+$(PREFIX)/opus.stamp: $(SRCDIR)/opus $(TOOLCHAIN_FILE)
+	@$(PRE_RULE)
+	cd $< && autoreconf -fi
+	mkdir -p $(BUILDDIR)/$(notdir $<)
+	cd $(BUILDDIR)/$(notdir $<) && $(SRCDIR)/$(notdir $<)/configure $($(notdir $<)_CONFIGURE)
+	$(MAKE) -C $(BUILDDIR)/$(notdir $<) install V=0
+	mkdir -p $(@D) && touch $@
+	@$(POST_RULE)
+
+#############################################################################
+# libvpx
+
+$(SRCDIR)/libvpx:
+	git clone --depth=1 --branch=v1.6.0 https://github.com/webmproject/libvpx $@
+	cd $@ && patch -p1 < $(CURDIR)/scripts/patches/libvpx.patch
+
+$(PREFIX)/libvpx.stamp: $(SRCDIR)/libvpx $(TOOLCHAIN_FILE)
+	@$(PRE_RULE)
+	mkdir -p $(BUILDDIR)/$(notdir $<)
+	cd $(BUILDDIR)/$(notdir $<) && $(SRCDIR)/$(notdir $<)/configure $($(notdir $<)_CONFIGURE)
+	$(MAKE) -C $(BUILDDIR)/$(notdir $<) install
+	mkdir -p $(@D) && touch $@
+	@$(POST_RULE)

--- a/scripts/patches/libvpx.patch
+++ b/scripts/patches/libvpx.patch
@@ -1,0 +1,274 @@
+diff --git a/build/make/configure.sh b/build/make/configure.sh
+index 4f0071b..f8e7b69 100644
+--- a/build/make/configure.sh
++++ b/build/make/configure.sh
+@@ -918,92 +918,6 @@ process_common_toolchain() {
+ 
+       asm_conversion_cmd="cat"
+ 
+-      case ${tgt_cc} in
+-        gcc)
+-          link_with_cc=gcc
+-          setup_gnu_toolchain
+-          arch_int=${tgt_isa##armv}
+-          arch_int=${arch_int%%te}
+-          check_add_asflags --defsym ARCHITECTURE=${arch_int}
+-          tune_cflags="-mtune="
+-          if [ ${tgt_isa} = "armv7" ] || [ ${tgt_isa} = "armv7s" ]; then
+-            if [ -z "${float_abi}" ]; then
+-              check_cpp <<EOF && float_abi=hard || float_abi=softfp
+-#ifndef __ARM_PCS_VFP
+-#error "not hardfp"
+-#endif
+-EOF
+-            fi
+-            check_add_cflags  -march=armv7-a -mfloat-abi=${float_abi}
+-            check_add_asflags -march=armv7-a -mfloat-abi=${float_abi}
+-
+-            if enabled neon || enabled neon_asm; then
+-              check_add_cflags -mfpu=neon #-ftree-vectorize
+-              check_add_asflags -mfpu=neon
+-            fi
+-          elif [ ${tgt_isa} = "arm64" ] || [ ${tgt_isa} = "armv8" ]; then
+-            check_add_cflags -march=armv8-a
+-            check_add_asflags -march=armv8-a
+-          else
+-            check_add_cflags -march=${tgt_isa}
+-            check_add_asflags -march=${tgt_isa}
+-          fi
+-
+-          enabled debug && add_asflags -g
+-          asm_conversion_cmd="${source_path}/build/make/ads2gas.pl"
+-          if enabled thumb; then
+-            asm_conversion_cmd="$asm_conversion_cmd -thumb"
+-            check_add_cflags -mthumb
+-            check_add_asflags -mthumb -mimplicit-it=always
+-          fi
+-          ;;
+-        vs*)
+-          asm_conversion_cmd="${source_path}/build/make/ads2armasm_ms.pl"
+-          AS_SFX=.s
+-          msvs_arch_dir=arm-msvs
+-          disable_feature multithread
+-          disable_feature unit_tests
+-          vs_version=${tgt_cc##vs}
+-          if [ $vs_version -ge 12 ]; then
+-            # MSVC 2013 doesn't allow doing plain .exe projects for ARM,
+-            # only "AppContainerApplication" which requires an AppxManifest.
+-            # Therefore disable the examples, just build the library.
+-            disable_feature examples
+-          fi
+-          ;;
+-        rvct)
+-          CC=armcc
+-          AR=armar
+-          AS=armasm
+-          LD="${source_path}/build/make/armlink_adapter.sh"
+-          STRIP=arm-none-linux-gnueabi-strip
+-          NM=arm-none-linux-gnueabi-nm
+-          tune_cflags="--cpu="
+-          tune_asflags="--cpu="
+-          if [ -z "${tune_cpu}" ]; then
+-            if [ ${tgt_isa} = "armv7" ]; then
+-              if enabled neon || enabled neon_asm
+-              then
+-                check_add_cflags --fpu=softvfp+vfpv3
+-                check_add_asflags --fpu=softvfp+vfpv3
+-              fi
+-              check_add_cflags --cpu=Cortex-A8
+-              check_add_asflags --cpu=Cortex-A8
+-            else
+-              check_add_cflags --cpu=${tgt_isa##armv}
+-              check_add_asflags --cpu=${tgt_isa##armv}
+-            fi
+-          fi
+-          arch_int=${tgt_isa##armv}
+-          arch_int=${arch_int%%te}
+-          check_add_asflags --pd "\"ARCHITECTURE SETA ${arch_int}\""
+-          enabled debug && add_asflags -g
+-          add_cflags --gnu
+-          add_cflags --enum_is_int
+-          add_cflags --wchar32
+-          ;;
+-      esac
+-
+       case ${tgt_os} in
+         none*)
+           disable_feature multithread
+@@ -1015,10 +929,16 @@ EOF
+             die "Must specify --sdk-path for Android builds."
+           fi
+ 
++          if [ ${tgt_isa} = "arm64" ]; then
++            TRIPLE=aarch64-linux-android
++          else
++            TRIPLE=arm-linux-androideabi
++          fi
++
+           SDK_PATH=${sdk_path}
+           COMPILER_LOCATION=`find "${SDK_PATH}" \
+-                             -name "arm-linux-androideabi-gcc*" -print -quit`
+-          TOOLCHAIN_PATH=${COMPILER_LOCATION%/*}/arm-linux-androideabi-
++                             -name "${TRIPLE}-gcc*" -print -quit`
++          TOOLCHAIN_PATH=${COMPILER_LOCATION%/*}/${TRIPLE}-
+           CC=${TOOLCHAIN_PATH}gcc
+           CXX=${TOOLCHAIN_PATH}g++
+           AR=${TOOLCHAIN_PATH}ar
+@@ -1041,9 +961,11 @@ EOF
+             add_ldflags "--sysroot=${alt_libc}"
+           fi
+ 
+-          # linker flag that routes around a CPU bug in some
+-          # Cortex-A8 implementations (NDK Dev Guide)
+-          add_ldflags "-Wl,--fix-cortex-a8"
++          if [ ${tgt_isa} != "arm64" ]; then
++            # linker flag that routes around a CPU bug in some
++            # Cortex-A8 implementations (NDK Dev Guide)
++            add_ldflags "-Wl,--fix-cortex-a8"
++          fi
+ 
+           enable_feature pic
+           soft_enable realtime_only
+@@ -1137,6 +1059,92 @@ EOF
+           fi
+           ;;
+       esac
++
++      case ${tgt_cc} in
++        gcc)
++          link_with_cc=gcc
++          setup_gnu_toolchain
++          arch_int=${tgt_isa##armv}
++          arch_int=${arch_int%%te}
++          check_add_asflags --defsym ARCHITECTURE=${arch_int}
++          tune_cflags="-mtune="
++          if [ ${tgt_isa} = "armv7" ] || [ ${tgt_isa} = "armv7s" ]; then
++            if [ -z "${float_abi}" ]; then
++              check_cpp <<EOF && float_abi=hard || float_abi=softfp
++#ifndef __ARM_PCS_VFP
++#error "not hardfp"
++#endif
++EOF
++            fi
++            check_add_cflags  -march=armv7-a -mfloat-abi=${float_abi}
++            check_add_asflags -march=armv7-a -mfloat-abi=${float_abi}
++
++            if enabled neon || enabled neon_asm; then
++              check_add_cflags -mfpu=neon #-ftree-vectorize
++              check_add_asflags -mfpu=neon
++            fi
++          elif [ ${tgt_isa} = "arm64" ] || [ ${tgt_isa} = "armv8" ]; then
++            check_add_cflags -march=armv8-a
++            check_add_asflags -march=armv8-a
++          else
++            check_add_cflags -march=${tgt_isa}
++            check_add_asflags -march=${tgt_isa}
++          fi
++
++          enabled debug && add_asflags -g
++          asm_conversion_cmd="${source_path}/build/make/ads2gas.pl"
++          if enabled thumb; then
++            asm_conversion_cmd="$asm_conversion_cmd -thumb"
++            check_add_cflags -mthumb
++            check_add_asflags -mthumb -mimplicit-it=always
++          fi
++          ;;
++        vs*)
++          asm_conversion_cmd="${source_path}/build/make/ads2armasm_ms.pl"
++          AS_SFX=.s
++          msvs_arch_dir=arm-msvs
++          disable_feature multithread
++          disable_feature unit_tests
++          vs_version=${tgt_cc##vs}
++          if [ $vs_version -ge 12 ]; then
++            # MSVC 2013 doesn't allow doing plain .exe projects for ARM,
++            # only "AppContainerApplication" which requires an AppxManifest.
++            # Therefore disable the examples, just build the library.
++            disable_feature examples
++          fi
++          ;;
++        rvct)
++          CC=armcc
++          AR=armar
++          AS=armasm
++          LD="${source_path}/build/make/armlink_adapter.sh"
++          STRIP=arm-none-linux-gnueabi-strip
++          NM=arm-none-linux-gnueabi-nm
++          tune_cflags="--cpu="
++          tune_asflags="--cpu="
++          if [ -z "${tune_cpu}" ]; then
++            if [ ${tgt_isa} = "armv7" ]; then
++              if enabled neon || enabled neon_asm
++              then
++                check_add_cflags --fpu=softvfp+vfpv3
++                check_add_asflags --fpu=softvfp+vfpv3
++              fi
++              check_add_cflags --cpu=Cortex-A8
++              check_add_asflags --cpu=Cortex-A8
++            else
++              check_add_cflags --cpu=${tgt_isa##armv}
++              check_add_asflags --cpu=${tgt_isa##armv}
++            fi
++          fi
++          arch_int=${tgt_isa##armv}
++          arch_int=${arch_int%%te}
++          check_add_asflags --pd "\"ARCHITECTURE SETA ${arch_int}\""
++          enabled debug && add_asflags -g
++          add_cflags --gnu
++          add_cflags --enum_is_int
++          add_cflags --wchar32
++          ;;
++      esac
+       ;;
+     mips*)
+       link_with_cc=gcc
+@@ -1188,6 +1196,17 @@ EOF
+           LD=${LD:-${CROSS}gcc}
+           CROSS=${CROSS-g}
+           ;;
++        android*)
++          case ${toolchain} in
++            x86_64*)
++              CROSS=${CROSS:-x86_64-linux-android-}
++              ;;
++            *)
++              CROSS=${CROSS:-i686-linux-android-}
++              ;;
++          esac
++          add_asflags -D__ANDROID__
++          ;;
+         os2)
+           disable_feature pic
+           AS=${AS:-nasm}
+diff --git a/configure b/configure
+index f82ee04..5de9866 100755
+--- a/configure
++++ b/configure
+@@ -97,6 +97,7 @@ EOF
+ 
+ # all_platforms is a list of all supported target platforms. Maintain
+ # alphabetically by architecture, generic-gnu last.
++all_platforms="${all_platforms} arm64-android-gcc"
+ all_platforms="${all_platforms} arm64-darwin-gcc"
+ all_platforms="${all_platforms} arm64-linux-gcc"
+ all_platforms="${all_platforms} armv6-linux-rvct"
+diff --git a/libs.mk b/libs.mk
+index 9a6092a..53d3e38 100644
+--- a/libs.mk
++++ b/libs.mk
+@@ -330,11 +330,11 @@ vpx.pc: config.mk libs.mk
+ 	$(qexec)echo 'Requires:' >> $@
+ 	$(qexec)echo 'Conflicts:' >> $@
+ 	$(qexec)echo 'Libs: -L$${libdir} -lvpx -lm' >> $@
+-ifeq ($(HAVE_PTHREAD_H),yes)
+-	$(qexec)echo 'Libs.private: -lm -lpthread' >> $@
+-else
++#ifeq ($(HAVE_PTHREAD_H),yes)
++#	$(qexec)echo 'Libs.private: -lm -lpthread' >> $@
++#else
+ 	$(qexec)echo 'Libs.private: -lm' >> $@
+-endif
++#endif
+ 	$(qexec)echo 'Cflags: -I$${includedir}' >> $@
+ INSTALL-LIBS-yes += $(LIBSUBDIR)/pkgconfig/vpx.pc
+ INSTALL_MAPS += $(LIBSUBDIR)/pkgconfig/%.pc %.pc

--- a/scripts/release.mk
+++ b/scripts/release.mk
@@ -1,0 +1,9 @@
+_build/$(TARGET)/tox4j/libtox4j-c$(DLLEXT): $(PREFIX)/tox4j.stamp
+	ls -l $@
+	touch $@
+
+release: _build/$(TARGET)/tox4j/libtox4j-c$(DLLEXT)
+	rm -rf $(wildcard $(SRCDIR)/tox4j/cpp/src/main/resources/im/tox/tox4j/impl/jni/*/)
+	mkdir -p $(SRCDIR)/tox4j/cpp/src/main/resources/im/tox/tox4j/impl/jni/$(TOX4J_PLATFORM)/
+	cp $< $(SRCDIR)/tox4j/cpp/src/main/resources/im/tox/tox4j/impl/jni/$(TOX4J_PLATFORM)/
+	cd $(SRCDIR)/tox4j/cpp && sbt publishM2


### PR DESCRIPTION
The scripts are from https://github.com/TokTok/jvm-toxcore-c/tree/master/scripts and have been modified to build with the latest LTS NDK, publish everything to a local maven repository, and to build the scala artifacts of jvm-macros, jvm-toxcore-c, and jvm-toxcore-api in addition to the jvm-toxcore-c jni artifacts.
