### PR TITLE
Dump logcat when Android tests fail in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 29
-        script: ./gradlew connectedCheck
+        script: ./gradlew connectedCheck || { adb logcat -d; exit 1; }
 
   ktlint:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
`quitting_does_not_crash(ltd.evilcorp.domain.tox.ToxTest)` seems to fail sporadically on CI. Not super surprising since it's pretty timing-dependent, but this will help diagnose whatever Android test explodes in the future.