### PR TITLE
Disable unstable test in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,11 +4,12 @@ jobs:
     runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
+    # TODO(robinlinden): Fix tests failing sporadically in CI.
     - name: Test
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 29
-        script: ./gradlew connectedCheck || { adb logcat -d; exit 1; }
+        script: ./gradlew connectedCheck -x :atox:connectedAndroidTest -x :domain:connectedAndroidTest || { adb logcat -d; exit 1; }
 
   ktlint:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Turns out that whatever changed to make them possible to run at all wasn't enough. They still crash sporadically. :(