### PR TITLE
Replace use of deprecated function

### DIFF
--- a/atox/src/main/kotlin/ui/NotificationHelper.kt
+++ b/atox/src/main/kotlin/ui/NotificationHelper.kt
@@ -127,7 +127,7 @@ class NotificationHelper @Inject constructor(
             )
 
         if (outgoing) {
-            notificationBuilder.setNotificationSilent()
+            notificationBuilder.setSilent(true)
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {


### PR DESCRIPTION
This was deprecated in the newer `androidx.core:core-ktx`, but Android Studio didn't warn about it until now for whatever reason.