### PR TITLE
Fix it being possible to get some settings stuck out of view

### DIFF
--- a/atox/src/main/kotlin/ui/user_profile/UserProfileFragment.kt
+++ b/atox/src/main/kotlin/ui/user_profile/UserProfileFragment.kt
@@ -99,5 +99,13 @@ class UserProfileFragment : BaseFragment<FragmentUserProfileBinding>(FragmentUse
         profileOptions.profileChangeStatus.setOnClickListener {
             StatusDialog(requireContext(), currentStatus) { status -> vm.setStatus(status) }.show()
         }
+
+        // TODO(robinlinden): Remove hack. It's used to make sure we can scroll to the settings
+        //  further down when in landscape orientation. This is only needed if the view is recreated
+        //  while we're on this screen as Android changes the size of the contents of the NestedScrollView
+        //  when that happens.
+        if (savedInstanceState != null) {
+            needsHacks.updatePadding(bottom = (150 * resources.displayMetrics.density).toInt())
+        }
     }
 }

--- a/atox/src/main/res/layout/fragment_user_profile.xml
+++ b/atox/src/main/res/layout/fragment_user_profile.xml
@@ -85,19 +85,16 @@
             android:id="@+id/main_section"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:paddingTop="16dp"
             android:scrollbars="vertical"
             app:layout_behavior="@string/appbar_scrolling_view_behavior">
-        <LinearLayout
+        <LinearLayout android:id="@+id/needsHacks"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:orientation="vertical">
             <androidx.cardview.widget.CardView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="16dp"
-                    android:layout_marginRight="16dp"
-                    android:layout_marginBottom="16dp">
+                    android:layout_margin="16dp">
                 <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"


### PR DESCRIPTION
This could only happen in landscape mode, and only if the view was
recreated while you were on it. No idea why Android decides to change
the size of it when recreating it, but here we are. If I think of a
nicer solution I'll revert this and fix it properly.