### PR TITLE
Make sure that authorities are unique between release and debug builds

### DIFF
--- a/atox/src/main/AndroidManifest.xml
+++ b/atox/src/main/AndroidManifest.xml
@@ -30,7 +30,7 @@
 
         <provider
                 android:name="androidx.core.content.FileProvider"
-                android:authorities="ltd.evilcorp.fileprovider"
+                android:authorities="${applicationId}.fileprovider"
                 android:exported="false"
                 android:grantUriPermissions="true">
             <meta-data

--- a/atox/src/main/kotlin/ui/chat/ChatFragment.kt
+++ b/atox/src/main/kotlin/ui/chat/ChatFragment.kt
@@ -28,6 +28,7 @@ import java.io.File
 import java.net.URLConnection
 import java.text.DateFormat
 import java.util.Locale
+import ltd.evilcorp.atox.BuildConfig
 import ltd.evilcorp.atox.R
 import ltd.evilcorp.atox.databinding.FragmentChatBinding
 import ltd.evilcorp.atox.requireStringArg
@@ -152,7 +153,7 @@ class ChatFragment : BaseFragment<FragmentChatBinding>(FragmentChatBinding::infl
                     val contentType = URLConnection.guessContentTypeFromName(ft.fileName)
                     val uri = FileProvider.getUriForFile(
                         requireContext(),
-                        "ltd.evilcorp.fileprovider",
+                        "${BuildConfig.APPLICATION_ID}.fileprovider",
                         File(Uri.parse(ft.destination).path!!)
                     )
                     val shareIntent = Intent(Intent.ACTION_VIEW).apply {


### PR DESCRIPTION
This is to make it possible to install the debug and release variants of
aTox alongside one another.