### PR TITLE
Fix tox4j build scripts

### DIFF
--- a/scripts/dependencies.mk
+++ b/scripts/dependencies.mk
@@ -105,7 +105,7 @@ $(PREFIX)/libsodium.stamp: $(SRCDIR)/libsodium $(TOOLCHAIN_FILE)
 
 # HEAD as of 2021-01-03
 $(SRCDIR)/opus:
-	git clone --depth=1 https://github.com/xiph/opus $@
+	git clone https://github.com/xiph/opus $@
 	cd $@ && git checkout 794392e
 
 $(PREFIX)/opus.stamp: $(SRCDIR)/opus $(TOOLCHAIN_FILE)


### PR DESCRIPTION
I accidentally left the --depth=1 flag on the Opus clone when moving it
from a tag to the latest commit on master. This worked until they pushed
a new latest commit.