### PR TITLE
Fix user status being shown as available after every start

### DIFF
--- a/domain/src/main/kotlin/feature/UserManager.kt
+++ b/domain/src/main/kotlin/feature/UserManager.kt
@@ -23,17 +23,12 @@ class UserManager @Inject constructor(
     }
 
     fun verifyExists(publicKey: PublicKey) = launch {
-        val name = tox.getName().await()
-        val statusMessage = tox.getStatusMessage().await()
-        val user = User(publicKey.string(), name, statusMessage)
-
         if (!userRepository.exists(publicKey.string())) {
+            val name = tox.getName().await()
+            val statusMessage = tox.getStatusMessage().await()
+            val user = User(publicKey.string(), name, statusMessage)
             userRepository.add(user)
-        } else {
-            userRepository.update(user)
         }
-
-        userRepository.update(user)
     }
 
     fun setName(name: String) = launch {


### PR DESCRIPTION
This was caused by code left in from back in the day before aTox had import functionality and I had to manually place my tox.save-file in the right folder to import it.

Thanks to @anthonybilinski for finding and reporting the bug! :D