### PR TITLE
Fix tests not building

### DIFF
--- a/atox/src/androidTest/kotlin/IntegrationTest.kt
+++ b/atox/src/androidTest/kotlin/IntegrationTest.kt
@@ -24,6 +24,7 @@ import io.mockk.mockk
 import javax.inject.Singleton
 import ltd.evilcorp.atox.di.AndroidModule
 import ltd.evilcorp.atox.di.AppComponent
+import ltd.evilcorp.atox.di.AppModule
 import ltd.evilcorp.atox.di.ViewModelModule
 import ltd.evilcorp.core.db.Database
 import ltd.evilcorp.core.di.DaoModule
@@ -60,7 +61,15 @@ class TestModule {
 }
 
 @Singleton
-@Component(modules = [AndroidModule::class, TestModule::class, DaoModule::class, ViewModelModule::class])
+@Component(
+    modules = [
+        AppModule::class,
+        AndroidModule::class,
+        TestModule::class,
+        DaoModule::class,
+        ViewModelModule::class
+    ]
+)
 interface TestComponent : AppComponent {
     @Component.Factory
     interface Factory {

--- a/domain/src/androidTest/kotlin/tox/ToxTest.kt
+++ b/domain/src/androidTest/kotlin/tox/ToxTest.kt
@@ -11,7 +11,8 @@ class ToxTest {
     @Test
     fun quitting_does_not_crash() {
         for (i in 1..10) {
-            val tox = Tox(mockk(relaxUnitFun = true), mockk(relaxUnitFun = true)).apply { isBootstrapNeeded = false }
+            val tox =
+                Tox(mockk(relaxUnitFun = true), mockk(relaxUnitFun = true), mockk()).apply { isBootstrapNeeded = false }
             tox.start(SaveOptions(null, false, ProxyType.None, "", 0), ToxEventListener(), ToxAvEventListener())
             sleep(25)
             tox.stop()


### PR DESCRIPTION
The integration test is having issues with `java.lang.ClassNotFoundException: Didn't find class "androidx.core.app.CoreComponentFactory"` on some emulators sometimes, but at least now it builds.