### PR TITLE
Replace embedded QR scanner with calling into an external app

### DIFF
--- a/atox/build.gradle.kts
+++ b/atox/build.gradle.kts
@@ -82,8 +82,6 @@ dependencies {
 
     implementation(Square.picasso)
 
-    implementation(JourneyApps.zxing)
-
     debugImplementation(Square.leakcanary)
 
     testImplementation(Test.junit)

--- a/atox/src/main/AndroidManifest.xml
+++ b/atox/src/main/AndroidManifest.xml
@@ -51,9 +51,5 @@
                 <data android:scheme="tox" />
             </intent-filter>
         </activity>
-
-        <activity android:name="com.journeyapps.barcodescanner.CaptureActivity"
-                android:screenOrientation="fullSensor"
-                tools:replace="screenOrientation"/>
     </application>
 </manifest>

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -108,11 +108,6 @@ object Google {
     }
 }
 
-object JourneyApps {
-    // 3.6.0 is the last version before API 24 was required.
-    const val zxing = "com.journeyapps:zxing-android-embedded:3.6.0"
-}
-
 object Square {
     const val picasso = "com.squareup.picasso:picasso:2.8"
     const val leakcanary = "com.squareup.leakcanary:leakcanary-android:2.6"


### PR DESCRIPTION
The embedded QR scanner was pinned to an old version due to support for
Android 4.4 being dropped in later versions. jcenter is going away, and
the replacement, mavencentral, doesn't have this ancient version of the
embedded scanner.

Part of #603 