### PR TITLE
Don't specify a nav graph in the manifest

### DIFF
--- a/atox/src/main/AndroidManifest.xml
+++ b/atox/src/main/AndroidManifest.xml
@@ -39,7 +39,6 @@
         </provider>
 
         <activity android:name=".MainActivity">
-            <nav-graph android:value="@navigation/nav_graph"/>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>


### PR DESCRIPTION
This is a leftover from when implicit deep-linking was used.