### PR TITLE
Fix the offline-bootstrap code not always running

### DIFF
--- a/atox/src/main/kotlin/ToxService.kt
+++ b/atox/src/main/kotlin/ToxService.kt
@@ -29,7 +29,7 @@ class ToxService : LifecycleService() {
     private val channelId = "ToxService"
     private val notificationId = 1984
 
-    private var connectionStatus = ConnectionStatus.None
+    private var connectionStatus: ConnectionStatus? = null
 
     private val notifier by lazy { getSystemService<NotificationManager>()!! }
     private var bootstrapTimer = Timer()
@@ -57,13 +57,13 @@ class ToxService : LifecycleService() {
         notifier.createNotificationChannels(listOf(friendRequestChannel))
     }
 
-    private fun subTextFor(status: ConnectionStatus) = when (status) {
-        ConnectionStatus.None -> getText(R.string.atox_offline)
+    private fun subTextFor(status: ConnectionStatus?) = when (status) {
+        null, ConnectionStatus.None -> getText(R.string.atox_offline)
         ConnectionStatus.TCP -> getText(R.string.atox_connected_with_tcp)
         ConnectionStatus.UDP -> getText(R.string.atox_connected_with_udp)
     }
 
-    private fun notificationFor(status: ConnectionStatus): Notification {
+    private fun notificationFor(status: ConnectionStatus?): Notification {
         val pendingIntent: PendingIntent =
             Intent(this, MainActivity::class.java).let { notificationIntent ->
                 PendingIntent.getActivity(this, 0, notificationIntent, 0)

--- a/atox/src/main/kotlin/ToxService.kt
+++ b/atox/src/main/kotlin/ToxService.kt
@@ -100,7 +100,7 @@ class ToxService : LifecycleService() {
                 notifier.notify(notificationId, notificationFor(connectionStatus))
                 if (connectionStatus == ConnectionStatus.None) {
                     Log.i(TAG, "Gone offline, scheduling bootstrap")
-                    bootstrapTimer.schedule(60_000) {
+                    bootstrapTimer.schedule(60_000, 60_000) {
                         Log.i(TAG, "Been offline for too long, bootstrapping")
                         tox.isBootstrapNeeded = true
                     }
@@ -119,6 +119,7 @@ class ToxService : LifecycleService() {
 
     override fun onDestroy() {
         super.onDestroy()
+        bootstrapTimer.cancel()
         tox.stop()
     }
 }


### PR DESCRIPTION
It failed to run after changing settings that would gracefully shut Tox
down as that sets the connection status to offline, meaning the that our
check for unique connection statuses would stop the bootstrap code from
running when creating a fresh Tox Service which initializes the
connection status to offline.