### PR TITLE
Don't treat lint warnings as errors

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -51,10 +51,6 @@ android {
     kotlinOptions {
         jvmTarget = Java.version.toString()
     }
-    lintOptions {
-        isAbortOnError = true
-        isWarningsAsErrors = true
-    }
     sourceSets["main"].java.srcDir("src/main/kotlin")
     sourceSets["test"].java.srcDir("src/test/kotlin")
     sourceSets["androidTest"].assets.srcDir("$projectDir/schemas")

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -47,8 +47,6 @@ android {
         )
     }
     lintOptions {
-        isAbortOnError = true
-        isWarningsAsErrors = true
         disable("InvalidPackage") // tox4j is still not really allowed on Android. :/
     }
     sourceSets["main"].java.srcDir("src/main/kotlin")


### PR DESCRIPTION
This doesn't seem to have any effect when building from Android Studio,
so they're only caught in CI which is a bit annoying. It also doesn't
seem to affect all lint warnings, so I need to manually go over them
before every release anyway.