### PR TITLE
Remove the last bit of jcenter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,11 +22,6 @@ allprojects {
         google()
         mavenCentral()
         maven { url = uri("https://dl.bintray.com/toktok/maven") }
-        jcenter {
-            content {
-                includeModule("org.jetbrains.trove4j", "trove4j")
-            }
-        }
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 plugins {
     `kotlin-dsl`


### PR DESCRIPTION
JetBrains have now migrated the old trove4j from jcenter to
mavenCentral.

https://youtrack.jetbrains.com/issue/IDEA-261387