### PR TITLE
Don't allow using a proxy together with UDP

### DIFF
--- a/atox/src/main/kotlin/ui/settings/SettingsFragment.kt
+++ b/atox/src/main/kotlin/ui/settings/SettingsFragment.kt
@@ -113,7 +113,12 @@ class SettingsFragment : BaseFragment<FragmentSettingsBinding>(FragmentSettingsB
             }
         }
 
+        if (vm.getProxyType() != ProxyType.None) {
+            vm.setUdpEnabled(false)
+        }
+
         settingsUdpEnabled.isChecked = vm.getUdpEnabled()
+        settingsUdpEnabled.isEnabled = vm.getProxyType() == ProxyType.None
         settingsUdpEnabled.setOnClickListener { vm.setUdpEnabled(settingsUdpEnabled.isChecked) }
 
         proxyType.adapter = ArrayAdapter.createFromResource(
@@ -125,7 +130,13 @@ class SettingsFragment : BaseFragment<FragmentSettingsBinding>(FragmentSettingsB
         proxyType.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onNothingSelected(parent: AdapterView<*>?) {}
             override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
-                vm.setProxyType(ProxyType.values()[position])
+                val selected = ProxyType.values()[position]
+                vm.setProxyType(selected)
+
+                // Disable UDP if a proxy is selected to ensure all traffic goes through the proxy.
+                settingsUdpEnabled.isEnabled = selected == ProxyType.None
+                settingsUdpEnabled.isChecked = settingsUdpEnabled.isChecked && selected == ProxyType.None
+                vm.setUdpEnabled(settingsUdpEnabled.isChecked)
             }
         }
 

--- a/atox/src/main/kotlin/ui/settings/SettingsViewModel.kt
+++ b/atox/src/main/kotlin/ui/settings/SettingsViewModel.kt
@@ -63,6 +63,7 @@ class SettingsViewModel @Inject constructor(
 
     fun getUdpEnabled(): Boolean = settings.udpEnabled
     fun setUdpEnabled(enabled: Boolean) {
+        if (enabled == getUdpEnabled()) return
         settings.udpEnabled = enabled
         restartNeeded = true
     }


### PR DESCRIPTION
This is safer as it forces all traffic through the proxy even if toxcore
doesn't do what it says about disabling UDP if the proxy doesn't support
relaying it.

https://github.com/TokTok/c-toxcore/blob/25a56c354937e9c8c4c50a64c3b4cfc099c34e29/toxcore/tox.h#L563-L564