### PR TITLE
Update the Android Gradle plugin for Android Studio 4.2.0

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -8,7 +8,7 @@ object Java {
 
 object BuildPlugin {
     private object Version {
-        const val gradle = "4.1.3"
+        const val gradle = "4.2.0"
     }
 
     const val androidApplication = "com.android.application"


### PR DESCRIPTION
Extracting this from #718 since that's a bit blocked by Bazel not yet supporting Kotlin 1.5.0 and I want this in ASAP.