### PR TITLE
fix ripple effect starts from middle

### DIFF
--- a/atox/src/main/res/drawable/disable_ripple_effect.xml
+++ b/atox/src/main/res/drawable/disable_ripple_effect.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/transparent" android:state_pressed="true"/>
+    <item android:drawable="@color/transparent" android:state_selected="true"/>
+    <item android:drawable="@color/transparent" android:state_focused="true"/>
+    <item android:drawable="@color/transparent"/>
+</selector>

--- a/atox/src/main/res/layout/contact_list_view_item.xml
+++ b/atox/src/main/res/layout/contact_list_view_item.xml
@@ -5,6 +5,7 @@
         android:id="@+id/contactListItem"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="?android:attr/selectableItemBackground"
         android:padding="10dp">
     <include android:id="@+id/profileImageLayout" layout="@layout/profile_image_layout"/>
 

--- a/atox/src/main/res/layout/fragment_contact_list.xml
+++ b/atox/src/main/res/layout/fragment_contact_list.xml
@@ -32,7 +32,10 @@
             <ListView android:id="@+id/contactList"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:background="@null"
                     android:clipToPadding="false"
+                    android:drawSelectorOnTop="true"
+                    android:listSelector="@drawable/disable_ripple_effect"
                     app:layout_constraintTop_toTopOf="parent"
                     tools:listitem="@layout/contact_list_view_item"/>
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/atox/src/main/res/values/colors.xml
+++ b/atox/src/main/res/values/colors.xml
@@ -20,6 +20,7 @@
     <item name="dialogBackground" type="color">#3E4651</item>
 
     <item name="transparentBar" type="color">#40000000</item>
+    <item name="transparent" type="color">#00000000</item>
 
     <array name="contactBackgrounds">
         <item>#f16364</item>


### PR DESCRIPTION
Hi :)
As I understood ListView has a bug that causes the ripple effect start from middle for the first tap and for next taps start from previous tap location.
I found disabling the default ListView ripple effect and add it manually to the list items will solve it :)

thanks you!