### PR TITLE
Remove now-unused camera permission

### DIFF
--- a/atox/src/main/AndroidManifest.xml
+++ b/atox/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         package="ltd.evilcorp.atox"
         android:installLocation="auto">
-    <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>


### PR DESCRIPTION
This hasn't been in use since the integrated QR code reader had to be
removed and was just forgotten then.