### PR TITLE
Set up a cache for Bazel build files in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,11 @@ jobs:
           echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/$NDK_VERSION" >> $GITHUB_ENV
       env:
         NDK_VERSION: 22.1.7171670
+    - name: Set up Bazel cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/bazel
+        key: bazel
     - name: Install
       run: wget https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 --output-document=bazelisk
     - name: Build


### PR DESCRIPTION
This brings the build time down from 13m6s to 1m29s.

[without cache](https://github.com/robinlinden/aTox/runs/2869582117?check_suite_focus=true)
[filling cache](https://github.com/robinlinden/aTox/runs/2869722474?check_suite_focus=true)
[filled cache](https://github.com/robinlinden/aTox/runs/2869781348?check_suite_focus=true)