### PR TITLE
Fix crash on tapping notification during file transfer

### DIFF
--- a/atox/src/main/kotlin/ui/chat/ChatFragment.kt
+++ b/atox/src/main/kotlin/ui/chat/ChatFragment.kt
@@ -4,6 +4,7 @@ import android.app.AlertDialog
 import android.content.ActivityNotFoundException
 import android.content.ClipData
 import android.content.ClipboardManager
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -50,6 +51,13 @@ import ltd.evilcorp.domain.tox.PublicKey
 const val CONTACT_PUBLIC_KEY = "publicKey"
 private const val MAX_CONFIRM_DELETE_STRING_LENGTH = 20
 
+class OpenMultiplePersistableDocuments : ActivityResultContracts.OpenMultipleDocuments() {
+    override fun createIntent(context: Context, input: Array<out String>): Intent {
+        return super.createIntent(context, input)
+            .addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
+    }
+}
+
 class ChatFragment : BaseFragment<FragmentChatBinding>(FragmentChatBinding::inflate) {
     private val viewModel: ChatViewModel by viewModels { vmFactory }
 
@@ -64,9 +72,10 @@ class ChatFragment : BaseFragment<FragmentChatBinding>(FragmentChatBinding::infl
     }
 
     private val attachFilesLauncher =
-        registerForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { files ->
+        registerForActivityResult(OpenMultiplePersistableDocuments()) { files ->
             viewModel.setActiveChat(PublicKey(contactPubKey))
             for (file in files) {
+                activity?.contentResolver?.takePersistableUriPermission(file, Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 viewModel.createFt(file)
             }
         }

--- a/domain/src/main/kotlin/feature/FileTransferManager.kt
+++ b/domain/src/main/kotlin/feature/FileTransferManager.kt
@@ -68,10 +68,11 @@ class FileTransferManager @Inject constructor(
         fileTransfers.filter { it.publicKey == pk }.forEach { ft ->
             setProgress(ft, FtRejected)
             fileTransfers.remove(ft)
-            File(ft.destination).delete()
             if (ft.outgoing) {
                 val uri = Uri.parse(ft.destination)
                 resolver.releasePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            } else {
+                File(ft.destination).delete()
             }
         }
     }
@@ -150,9 +151,10 @@ class FileTransferManager @Inject constructor(
         setProgress(ft, FtRejected)
         tox.stopFileTransfer(PublicKey(ft.publicKey), ft.fileNumber)
         val uri = Uri.parse(ft.destination)
-        File(uri.path!!).delete()
         if (ft.outgoing) {
             resolver.releasePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        } else {
+            File(uri.path!!).delete()
         }
     }
 

--- a/domain/src/main/kotlin/feature/FileTransferManager.kt
+++ b/domain/src/main/kotlin/feature/FileTransferManager.kt
@@ -248,14 +248,18 @@ class FileTransferManager @Inject constructor(
             return
         }
 
-        val bytes = resolver.openInputStream(src)?.use {
-            it.skip(pos)
-            val bytes = ByteArray(length)
-            it.read(bytes, 0, length)
-            bytes
-        } ?: return
-        tox.sendFileChunk(PublicKey(pk), fileNo, pos, bytes)
-        setProgress(ft, ft.progress + length)
+        try {
+            val bytes = resolver.openInputStream(src)?.use {
+                it.skip(pos)
+                val bytes = ByteArray(length)
+                it.read(bytes, 0, length)
+                bytes
+            } ?: return
+            tox.sendFileChunk(PublicKey(pk), fileNo, pos, bytes)
+            setProgress(ft, ft.progress + length)
+        } catch (e: SecurityException) {
+            Log.e(TAG, "sendChunk: $e")
+        }
     }
 
     fun setStatus(pk: String, fileNo: Int, fileStatus: ToxFileControl) {


### PR DESCRIPTION
For some reason Android revokes permissions when that happens. Seems
odd, but oh well.

Fixes #777 