### PR TITLE
Fix Kotlin 1.5.0 deprecations

### DIFF
--- a/atox/src/main/kotlin/ui/chat/ChatAdapter.kt
+++ b/atox/src/main/kotlin/ui/chat/ChatAdapter.kt
@@ -229,7 +229,7 @@ class ChatAdapter(
                 vh.progress.progress = fileTransfer.progress.toInt()
                 // TODO(robinlinden): paused, but that requires a database update and a release is overdue.
                 val stateId = if (fileTransfer.isRejected()) R.string.cancelled else R.string.completed
-                vh.state.text = resources.getString(stateId).toLowerCase(Locale.getDefault())
+                vh.state.text = resources.getString(stateId).lowercase(Locale.getDefault())
                 vh.timestamp.text = timeFormatter.format(message.timestamp)
 
                 vh.timestamp.visibility = if (position == messages.lastIndex) {

--- a/atox/src/main/kotlin/ui/chat/ChatFragment.kt
+++ b/atox/src/main/kotlin/ui/chat/ChatFragment.kt
@@ -187,7 +187,7 @@ class ChatFragment : BaseFragment<FragmentChatBinding>(FragmentChatBinding::infl
                 it.typing -> getString(R.string.contact_typing)
                 it.lastMessage == 0L -> getString(R.string.never)
                 else -> DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT).format(it.lastMessage)
-            }.toLowerCase(Locale.getDefault())
+            }.lowercase(Locale.getDefault())
 
             profileLayout.statusIndicator.setColorFilter(colorByStatus(resources, it))
             setAvatarFromContact(profileLayout.profileImage, it)

--- a/domain/src/main/kotlin/tox/ToxTypes.kt
+++ b/domain/src/main/kotlin/tox/ToxTypes.kt
@@ -4,7 +4,8 @@
 
 package ltd.evilcorp.domain.tox
 
-inline class PublicKey(private val value: String) {
+@JvmInline
+value class PublicKey(private val value: String) {
     fun bytes() = value.hexToBytes()
     fun string() = value
     fun fingerprint(): String {
@@ -17,7 +18,8 @@ inline class PublicKey(private val value: String) {
     }
 }
 
-inline class ToxID(private val value: String) {
+@JvmInline
+value class ToxID(private val value: String) {
     fun bytes() = value.hexToBytes()
     fun string() = value
 

--- a/domain/src/main/kotlin/tox/ToxUtil.kt
+++ b/domain/src/main/kotlin/tox/ToxUtil.kt
@@ -11,13 +11,12 @@ import im.tox.tox4j.core.enums.ToxUserStatus
 import im.tox.tox4j.core.options.ProxyOptions
 import im.tox.tox4j.core.options.SaveDataOptions
 import im.tox.tox4j.core.options.ToxOptions
-import java.util.Locale
 import ltd.evilcorp.core.vo.ConnectionStatus
 import ltd.evilcorp.core.vo.FileKind
 import ltd.evilcorp.core.vo.MessageType
 import ltd.evilcorp.core.vo.UserStatus
 
-fun String.hexToBytes(): ByteArray = chunked(2).map { it.toUpperCase(Locale.ROOT).toInt(16).toByte() }.toByteArray()
+fun String.hexToBytes(): ByteArray = chunked(2).map { it.uppercase().toInt(16).toByte() }.toByteArray()
 fun ByteArray.bytesToHex(): String = this.joinToString("") { "%02X".format(it) }
 fun ToxUserStatus.toUserStatus(): UserStatus = UserStatus.values()[this.ordinal]
 fun ToxConnection.toConnectionStatus(): ConnectionStatus = ConnectionStatus.values()[this.ordinal]

--- a/domain/src/test/kotlin/tox/ToxUtilTest.kt
+++ b/domain/src/test/kotlin/tox/ToxUtilTest.kt
@@ -8,7 +8,6 @@ import im.tox.tox4j.core.enums.ToxConnection
 import im.tox.tox4j.core.enums.ToxFileKind
 import im.tox.tox4j.core.enums.ToxMessageType
 import im.tox.tox4j.core.enums.ToxUserStatus
-import java.util.Locale
 import ltd.evilcorp.core.vo.ConnectionStatus
 import ltd.evilcorp.core.vo.FileKind
 import ltd.evilcorp.core.vo.MessageType
@@ -78,7 +77,7 @@ class ToxUtilTest {
     fun `public keys can be converted`() {
         val keyString = "76518406F6A9F2217E8DC487CC783C25CC16A15EB36FF32E335A235342C48A39"
         assert(keyString.hexToBytes().size == 32)
-        assertEquals(keyString, keyString.hexToBytes().bytesToHex().toUpperCase(Locale.ROOT))
+        assertEquals(keyString, keyString.hexToBytes().bytesToHex().uppercase())
 
         val keyBytes = byteArrayOf(
             0x76, 0x51, 0x84, 0x06, 0xF6, 0xA9, 0xF2, 0x21, 0x7E, 0x8D, 0xC4, 0x87, 0xCC, 0x78, 0x3C, 0x25,
@@ -89,7 +88,7 @@ class ToxUtilTest {
         assert(keyBytes.contentEquals(keyString.hexToBytes()))
 
         val anotherKeyString = "7B6704162C6532A5A8F0840A3680672D0E9D3E62B6419FFD88D9880669482169"
-        assertEquals(anotherKeyString, anotherKeyString.hexToBytes().bytesToHex().toUpperCase(Locale.ROOT))
+        assertEquals(anotherKeyString, anotherKeyString.hexToBytes().bytesToHex().uppercase())
         assertNotEquals(anotherKeyString.hexToBytes(), keyString.hexToBytes())
     }
 
@@ -97,8 +96,8 @@ class ToxUtilTest {
     fun `casing of public keys does not matter`() {
         val keyString = "76518406F6A9F2217E8DC487CC783C25CC16A15EB36FF32E335A235342C48A39"
         assertArrayEquals(
-            keyString.toUpperCase(Locale.ROOT).hexToBytes(),
-            keyString.toLowerCase(Locale.ROOT).hexToBytes()
+            keyString.uppercase().hexToBytes(),
+            keyString.lowercase().hexToBytes()
         )
     }
 }


### PR DESCRIPTION
This is currently blocked by Bazel not yet supporting Kotlin 1.5.0 and newer.