### PR TITLE
Update to Kotlin 1.5.21

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,6 @@
 import org.gradle.api.JavaVersion
 
-const val kotlinVersion = "1.5.20"
+const val kotlinVersion = "1.5.21"
 
 object Java {
     val version = JavaVersion.VERSION_1_8


### PR DESCRIPTION
Nothing too interesting, but it contains a bugfix for kapt ignoring the
java compiler options passed which affected us.