### PR TITLE
Update the Android Gradle plugin for Android Studio 2020.3.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@ jobs:
     runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 11
     # TODO(robinlinden): Fix tests failing sporadically in CI.
     - name: Test
       uses: reactivecircus/android-emulator-runner@v2
@@ -17,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: ktlint
       run: ./gradlew ktlint
 
@@ -41,7 +44,7 @@ jobs:
   #   - uses: actions/checkout@v2
   #   - uses: actions/setup-java@v1
   #     with:
-  #       java-version: 1.8
+  #       java-version: 11
   #   - name: Build and test
   #     run: ./gradlew build
 
@@ -51,7 +54,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Set up cache
       id: cache
       uses: actions/cache@v2

--- a/atox/build.gradle.kts
+++ b/atox/build.gradle.kts
@@ -8,11 +8,11 @@ plugins {
 apply<KtlintPlugin>()
 
 android {
-    compileSdkVersion(AndroidSdk.targetVersion)
+    compileSdk = AndroidSdk.targetVersion
     defaultConfig {
         applicationId = "ltd.evilcorp.atox"
-        minSdkVersion(AndroidSdk.minVersion)
-        targetSdkVersion(AndroidSdk.targetVersion)
+        minSdk = AndroidSdk.minVersion
+        targetSdk = AndroidSdk.targetVersion
         versionCode = 9
         versionName = "0.6.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -37,7 +37,7 @@ android {
     kotlinOptions {
         jvmTarget = Java.version.toString()
     }
-    lintOptions {
+    lint {
         disable("GoogleAppIndexingWarning", "MissingTranslation", "InvalidPackage")
     }
     sourceSets["main"].java.srcDir("src/main/kotlin")
@@ -45,7 +45,7 @@ android {
     packagingOptions {
         // Work around scala-compiler and scala-library (via tox4j) trying to place files in the
         // same place.
-        exclude("rootdoc.txt")
+        resources.excludes.add("rootdoc.txt")
     }
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -8,7 +8,7 @@ object Java {
 
 object BuildPlugin {
     private object Version {
-        const val gradle = "4.2.2"
+        const val gradle = "7.0.0"
     }
 
     const val androidApplication = "com.android.application"

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -20,12 +20,10 @@ plugins {
 apply<KtlintPlugin>()
 
 android {
-    compileSdkVersion(AndroidSdk.targetVersion)
+    compileSdk = AndroidSdk.targetVersion
     defaultConfig {
-        minSdkVersion(AndroidSdk.minVersion)
-        targetSdkVersion(AndroidSdk.targetVersion)
-        versionCode = 1
-        versionName = "0.1.0"
+        minSdk = AndroidSdk.minVersion
+        targetSdk = AndroidSdk.targetVersion
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         javaCompileOptions {
             annotationProcessorOptions {

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -20,12 +20,10 @@ plugins {
 apply<KtlintPlugin>()
 
 android {
-    compileSdkVersion(AndroidSdk.targetVersion)
+    compileSdk = AndroidSdk.targetVersion
     defaultConfig {
-        minSdkVersion(AndroidSdk.minVersion)
-        targetSdkVersion(AndroidSdk.targetVersion)
-        versionCode = 1
-        versionName = "0.1.0"
+        minSdk = AndroidSdk.minVersion
+        targetSdk = AndroidSdk.targetVersion
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled = true
     }
@@ -42,7 +40,7 @@ android {
     kotlinOptions {
         jvmTarget = Java.version.toString()
     }
-    lintOptions {
+    lint {
         disable("InvalidPackage") // tox4j is still not really allowed on Android. :/
         // The macOS domain:lint task fails due to not guarding AudioRecord with permission checks in this module.
         // This doesn't fail locally, and use of the audio code is guarded in the UI in the aTox module.
@@ -54,7 +52,7 @@ android {
     packagingOptions {
         // Work around scala-compiler and scala-library (via tox4j) trying to place files in the
         // same place.
-        exclude("rootdoc.txt")
+        resources.excludes.add("rootdoc.txt")
     }
 }
 


### PR DESCRIPTION
`sourceCompatibility`, `targetCompatibility`, and `jvmTarget` were all left at `1.8` as switching it to `11` causes [build failures](https://stackoverflow.com/questions/63677706/symbol-cursor-not-found-in-android-application-with-room-on-java-11) in the code generated by Room.