### PR TITLE
Add copyright and licensing information to source files

### DIFF
--- a/atox/src/androidTest/kotlin/IntegrationTest.kt
+++ b/atox/src/androidTest/kotlin/IntegrationTest.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox
 
 import android.app.Activity

--- a/atox/src/main/kotlin/ActionReceiver.kt
+++ b/atox/src/main/kotlin/ActionReceiver.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox
 
 import android.Manifest

--- a/atox/src/main/kotlin/App.kt
+++ b/atox/src/main/kotlin/App.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox
 
 import androidx.annotation.VisibleForTesting

--- a/atox/src/main/kotlin/AutoAway.kt
+++ b/atox/src/main/kotlin/AutoAway.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox
 
 import android.util.Log

--- a/atox/src/main/kotlin/BootReceiver.kt
+++ b/atox/src/main/kotlin/BootReceiver.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox
 
 import android.content.BroadcastReceiver

--- a/atox/src/main/kotlin/Extensions.kt
+++ b/atox/src/main/kotlin/Extensions.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox
 
 import android.content.Context

--- a/atox/src/main/kotlin/MainActivity.kt
+++ b/atox/src/main/kotlin/MainActivity.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox
 
 import android.content.Intent

--- a/atox/src/main/kotlin/ToxService.kt
+++ b/atox/src/main/kotlin/ToxService.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox
 
 import android.app.Notification

--- a/atox/src/main/kotlin/di/AndroidModule.kt
+++ b/atox/src/main/kotlin/di/AndroidModule.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.di
 
 import android.content.ContentResolver

--- a/atox/src/main/kotlin/di/AppComponent.kt
+++ b/atox/src/main/kotlin/di/AppComponent.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.di
 
 import android.content.Context

--- a/atox/src/main/kotlin/di/AppModule.kt
+++ b/atox/src/main/kotlin/di/AppModule.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.di
 
 import dagger.Module

--- a/atox/src/main/kotlin/di/ViewModelFactory.kt
+++ b/atox/src/main/kotlin/di/ViewModelFactory.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.di
 
 import androidx.lifecycle.ViewModel

--- a/atox/src/main/kotlin/di/ViewModelModule.kt
+++ b/atox/src/main/kotlin/di/ViewModelModule.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.di
 
 import androidx.lifecycle.ViewModel

--- a/atox/src/main/kotlin/settings/Settings.kt
+++ b/atox/src/main/kotlin/settings/Settings.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.settings
 
 import android.content.ComponentName

--- a/atox/src/main/kotlin/tox/BootstrapNodeRegistryImpl.kt
+++ b/atox/src/main/kotlin/tox/BootstrapNodeRegistryImpl.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.tox
 
 import android.content.Context

--- a/atox/src/main/kotlin/tox/EventListenerCallbacks.kt
+++ b/atox/src/main/kotlin/tox/EventListenerCallbacks.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.tox
 
 import android.content.Context

--- a/atox/src/main/kotlin/tox/ToxStarter.kt
+++ b/atox/src/main/kotlin/tox/ToxStarter.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.tox
 
 import android.content.Context

--- a/atox/src/main/kotlin/ui/BaseFragment.kt
+++ b/atox/src/main/kotlin/ui/BaseFragment.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui
 
 import android.os.Bundle

--- a/atox/src/main/kotlin/ui/NotificationHelper.kt
+++ b/atox/src/main/kotlin/ui/NotificationHelper.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui
 
 import android.app.NotificationManager

--- a/atox/src/main/kotlin/ui/ReceiveShareDialog.kt
+++ b/atox/src/main/kotlin/ui/ReceiveShareDialog.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui
 
 import android.app.Dialog

--- a/atox/src/main/kotlin/ui/StatusDialog.kt
+++ b/atox/src/main/kotlin/ui/StatusDialog.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui
 
 import android.app.Dialog

--- a/atox/src/main/kotlin/ui/Util.kt
+++ b/atox/src/main/kotlin/ui/Util.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui
 
 import android.content.res.Resources

--- a/atox/src/main/kotlin/ui/addcontact/AddContactFragment.kt
+++ b/atox/src/main/kotlin/ui/addcontact/AddContactFragment.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui.addcontact
 
 import android.app.Activity.RESULT_OK

--- a/atox/src/main/kotlin/ui/addcontact/AddContactViewModel.kt
+++ b/atox/src/main/kotlin/ui/addcontact/AddContactViewModel.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui.addcontact
 
 import androidx.lifecycle.LiveData

--- a/atox/src/main/kotlin/ui/call/CallFragment.kt
+++ b/atox/src/main/kotlin/ui/call/CallFragment.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui.call
 
 import android.Manifest

--- a/atox/src/main/kotlin/ui/call/CallViewModel.kt
+++ b/atox/src/main/kotlin/ui/call/CallViewModel.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui.call
 
 import androidx.lifecycle.LiveData

--- a/atox/src/main/kotlin/ui/chat/ChatAdapter.kt
+++ b/atox/src/main/kotlin/ui/chat/ChatAdapter.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui.chat
 
 import android.content.res.Resources

--- a/atox/src/main/kotlin/ui/chat/ChatFragment.kt
+++ b/atox/src/main/kotlin/ui/chat/ChatFragment.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui.chat
 
 import android.app.AlertDialog

--- a/atox/src/main/kotlin/ui/chat/ChatViewModel.kt
+++ b/atox/src/main/kotlin/ui/chat/ChatViewModel.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui.chat
 
 import android.content.ContentResolver

--- a/atox/src/main/kotlin/ui/contact_profile/ContactProfileFragment.kt
+++ b/atox/src/main/kotlin/ui/contact_profile/ContactProfileFragment.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui.contact_profile
 
 import android.os.Bundle

--- a/atox/src/main/kotlin/ui/contact_profile/ContactProfileViewModel.kt
+++ b/atox/src/main/kotlin/ui/contact_profile/ContactProfileViewModel.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui.contact_profile
 
 import androidx.lifecycle.LiveData

--- a/atox/src/main/kotlin/ui/contactlist/ContactAdapter.kt
+++ b/atox/src/main/kotlin/ui/contactlist/ContactAdapter.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui.contactlist
 
 import android.content.res.Resources

--- a/atox/src/main/kotlin/ui/contactlist/ContactListFragment.kt
+++ b/atox/src/main/kotlin/ui/contactlist/ContactListFragment.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui.contactlist
 
 import android.os.Bundle

--- a/atox/src/main/kotlin/ui/contactlist/ContactListViewModel.kt
+++ b/atox/src/main/kotlin/ui/contactlist/ContactListViewModel.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui.contactlist
 
 import android.content.ContentResolver

--- a/atox/src/main/kotlin/ui/create_profile/CreateProfileFragment.kt
+++ b/atox/src/main/kotlin/ui/create_profile/CreateProfileFragment.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui.create_profile
 
 import android.os.Bundle

--- a/atox/src/main/kotlin/ui/create_profile/CreateProfileViewModel.kt
+++ b/atox/src/main/kotlin/ui/create_profile/CreateProfileViewModel.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui.create_profile
 
 import android.content.ContentResolver

--- a/atox/src/main/kotlin/ui/friend_request/FriendRequestFragment.kt
+++ b/atox/src/main/kotlin/ui/friend_request/FriendRequestFragment.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui.friend_request
 
 import android.os.Bundle

--- a/atox/src/main/kotlin/ui/friend_request/FriendRequestViewModel.kt
+++ b/atox/src/main/kotlin/ui/friend_request/FriendRequestViewModel.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui.friend_request
 
 import androidx.lifecycle.LiveData

--- a/atox/src/main/kotlin/ui/settings/SettingsFragment.kt
+++ b/atox/src/main/kotlin/ui/settings/SettingsFragment.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui.settings
 
 import android.content.Context

--- a/atox/src/main/kotlin/ui/settings/SettingsViewModel.kt
+++ b/atox/src/main/kotlin/ui/settings/SettingsViewModel.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui.settings
 
 import android.content.ContentResolver

--- a/atox/src/main/kotlin/ui/user_profile/UserProfileFragment.kt
+++ b/atox/src/main/kotlin/ui/user_profile/UserProfileFragment.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui.user_profile
 
 import android.content.ClipData

--- a/atox/src/main/kotlin/ui/user_profile/UserProfileViewModel.kt
+++ b/atox/src/main/kotlin/ui/user_profile/UserProfileViewModel.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.atox.ui.user_profile
 
 import androidx.lifecycle.LiveData

--- a/core/src/androidTest/kotlin/db/ContactDaoTest.kt
+++ b/core/src/androidTest/kotlin/db/ContactDaoTest.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.db
 
 import androidx.room.Room

--- a/core/src/androidTest/kotlin/db/DatabaseMigrationTest.kt
+++ b/core/src/androidTest/kotlin/db/DatabaseMigrationTest.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.db
 
 import androidx.room.testing.MigrationTestHelper

--- a/core/src/androidTest/kotlin/db/UserDaoTest.kt
+++ b/core/src/androidTest/kotlin/db/UserDaoTest.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.db
 
 import androidx.room.Room

--- a/core/src/main/kotlin/db/ContactDao.kt
+++ b/core/src/main/kotlin/db/ContactDao.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.db
 
 import androidx.room.Dao

--- a/core/src/main/kotlin/db/Converters.kt
+++ b/core/src/main/kotlin/db/Converters.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.db
 
 import androidx.room.TypeConverter

--- a/core/src/main/kotlin/db/Database.kt
+++ b/core/src/main/kotlin/db/Database.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.db
 
 import androidx.room.Database

--- a/core/src/main/kotlin/db/FileTransferDao.kt
+++ b/core/src/main/kotlin/db/FileTransferDao.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.db
 
 import androidx.room.Dao

--- a/core/src/main/kotlin/db/FriendRequestDao.kt
+++ b/core/src/main/kotlin/db/FriendRequestDao.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.db
 
 import androidx.room.Dao

--- a/core/src/main/kotlin/db/MessageDao.kt
+++ b/core/src/main/kotlin/db/MessageDao.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.db
 
 import androidx.room.Dao

--- a/core/src/main/kotlin/db/Migration.kt
+++ b/core/src/main/kotlin/db/Migration.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.db
 
 import androidx.room.migration.Migration

--- a/core/src/main/kotlin/db/UserDao.kt
+++ b/core/src/main/kotlin/db/UserDao.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.db
 
 import androidx.room.Dao

--- a/core/src/main/kotlin/di/DatabaseModule.kt
+++ b/core/src/main/kotlin/di/DatabaseModule.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.di
 
 import android.content.Context

--- a/core/src/main/kotlin/repository/ContactRepository.kt
+++ b/core/src/main/kotlin/repository/ContactRepository.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.repository
 
 import javax.inject.Inject

--- a/core/src/main/kotlin/repository/FileTransferRepository.kt
+++ b/core/src/main/kotlin/repository/FileTransferRepository.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.repository
 
 import javax.inject.Inject

--- a/core/src/main/kotlin/repository/FriendRequestRepository.kt
+++ b/core/src/main/kotlin/repository/FriendRequestRepository.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.repository
 
 import javax.inject.Inject

--- a/core/src/main/kotlin/repository/MessageRepository.kt
+++ b/core/src/main/kotlin/repository/MessageRepository.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.repository
 
 import java.util.Date

--- a/core/src/main/kotlin/repository/UserRepository.kt
+++ b/core/src/main/kotlin/repository/UserRepository.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.repository
 
 import javax.inject.Inject

--- a/core/src/main/kotlin/vo/Contact.kt
+++ b/core/src/main/kotlin/vo/Contact.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.vo
 
 import androidx.room.ColumnInfo

--- a/core/src/main/kotlin/vo/FileTransfer.kt
+++ b/core/src/main/kotlin/vo/FileTransfer.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.vo
 
 import androidx.room.ColumnInfo

--- a/core/src/main/kotlin/vo/FriendRequest.kt
+++ b/core/src/main/kotlin/vo/FriendRequest.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.vo
 
 import androidx.room.ColumnInfo

--- a/core/src/main/kotlin/vo/Message.kt
+++ b/core/src/main/kotlin/vo/Message.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.vo
 
 import androidx.room.ColumnInfo

--- a/core/src/main/kotlin/vo/User.kt
+++ b/core/src/main/kotlin/vo/User.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.vo
 
 import androidx.room.ColumnInfo

--- a/core/src/test/kotlin/db/ConvertersTest.kt
+++ b/core/src/test/kotlin/db/ConvertersTest.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.core.db
 
 import ltd.evilcorp.core.vo.ConnectionStatus

--- a/domain/src/androidTest/kotlin/tox/ToxTest.kt
+++ b/domain/src/androidTest/kotlin/tox/ToxTest.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.tox
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/domain/src/main/kotlin/av/AudioCapture.kt
+++ b/domain/src/main/kotlin/av/AudioCapture.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.av
 
 import android.media.AudioFormat

--- a/domain/src/main/kotlin/av/AudioPlayer.kt
+++ b/domain/src/main/kotlin/av/AudioPlayer.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.av
 
 import android.media.AudioAttributes

--- a/domain/src/main/kotlin/feature/CallManager.kt
+++ b/domain/src/main/kotlin/feature/CallManager.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.feature
 
 import android.content.Context

--- a/domain/src/main/kotlin/feature/ChatManager.kt
+++ b/domain/src/main/kotlin/feature/ChatManager.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.feature
 
 import java.nio.ByteBuffer

--- a/domain/src/main/kotlin/feature/ContactManager.kt
+++ b/domain/src/main/kotlin/feature/ContactManager.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.feature
 
 import javax.inject.Inject

--- a/domain/src/main/kotlin/feature/FileTransferManager.kt
+++ b/domain/src/main/kotlin/feature/FileTransferManager.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.feature
 
 import android.content.ContentResolver

--- a/domain/src/main/kotlin/feature/FriendRequestManager.kt
+++ b/domain/src/main/kotlin/feature/FriendRequestManager.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.feature
 
 import javax.inject.Inject

--- a/domain/src/main/kotlin/feature/UserManager.kt
+++ b/domain/src/main/kotlin/feature/UserManager.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.feature
 
 import javax.inject.Inject

--- a/domain/src/main/kotlin/tox/BootstrapNodeJsonParser.kt
+++ b/domain/src/main/kotlin/tox/BootstrapNodeJsonParser.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.tox
 
 import android.util.Log

--- a/domain/src/main/kotlin/tox/BootstrapNodeRegistry.kt
+++ b/domain/src/main/kotlin/tox/BootstrapNodeRegistry.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.tox
 
 interface BootstrapNodeRegistry {

--- a/domain/src/main/kotlin/tox/SaveManager.kt
+++ b/domain/src/main/kotlin/tox/SaveManager.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.tox
 
 import android.content.Context

--- a/domain/src/main/kotlin/tox/SaveOptions.kt
+++ b/domain/src/main/kotlin/tox/SaveOptions.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.tox
 
 enum class ProxyType {

--- a/domain/src/main/kotlin/tox/Tox.kt
+++ b/domain/src/main/kotlin/tox/Tox.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.tox
 
 import android.util.Log

--- a/domain/src/main/kotlin/tox/ToxAvEventListener.kt
+++ b/domain/src/main/kotlin/tox/ToxAvEventListener.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.tox
 
 import im.tox.tox4j.av.callbacks.ToxAvEventListener

--- a/domain/src/main/kotlin/tox/ToxConstants.kt
+++ b/domain/src/main/kotlin/tox/ToxConstants.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.tox
 
 const val MAX_MESSAGE_LENGTH = 1372

--- a/domain/src/main/kotlin/tox/ToxEventListener.kt
+++ b/domain/src/main/kotlin/tox/ToxEventListener.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.tox
 
 import im.tox.tox4j.core.callbacks.ToxCoreEventListener

--- a/domain/src/main/kotlin/tox/ToxIdValidator.kt
+++ b/domain/src/main/kotlin/tox/ToxIdValidator.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.tox
 
 class ToxIdValidator {

--- a/domain/src/main/kotlin/tox/ToxSaveTester.kt
+++ b/domain/src/main/kotlin/tox/ToxSaveTester.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.tox
 
 import im.tox.tox4j.core.exceptions.ToxNewException

--- a/domain/src/main/kotlin/tox/ToxTypes.kt
+++ b/domain/src/main/kotlin/tox/ToxTypes.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.tox
 
 inline class PublicKey(private val value: String) {

--- a/domain/src/main/kotlin/tox/ToxUtil.kt
+++ b/domain/src/main/kotlin/tox/ToxUtil.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.tox
 
 import im.tox.tox4j.core.enums.ToxConnection

--- a/domain/src/main/kotlin/tox/ToxWrapper.kt
+++ b/domain/src/main/kotlin/tox/ToxWrapper.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.tox
 
 import android.util.Log

--- a/domain/src/test/kotlin/tox/ToxIdValidatorTest.kt
+++ b/domain/src/test/kotlin/tox/ToxIdValidatorTest.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.tox
 
 import org.junit.Assert

--- a/domain/src/test/kotlin/tox/ToxTypesTest.kt
+++ b/domain/src/test/kotlin/tox/ToxTypesTest.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.tox
 
 import org.junit.Assert.assertEquals

--- a/domain/src/test/kotlin/tox/ToxUtilTest.kt
+++ b/domain/src/test/kotlin/tox/ToxUtilTest.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2020 aTox contributors
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
 package ltd.evilcorp.domain.tox
 
 import im.tox.tox4j.core.enums.ToxConnection


### PR DESCRIPTION
I'm the sole copyright holder of like 99% of this, but just using `aTox contributors` is more convenient in case anyone else contributes too.

The copyright headers were created using git log to check which years commits were made to the files.

Eventually I'd like to get `reuse lint` passing on aTox, but that's for future me to continue working on.

See: https://reuse.software/