### PR TITLE
Update to Kotlin 1.5.30

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,6 @@
 import org.gradle.api.JavaVersion
 
-const val kotlinVersion = "1.5.21"
+const val kotlinVersion = "1.5.30"
 
 object Java {
     val version = JavaVersion.VERSION_1_8


### PR DESCRIPTION
Just updating the patch of io_bazel_rules_kotlin to use 1.5.30 instead
of 1.5.21 causes kapt to crash, so I will have to spend more time
investigating that before updating the Bazel build.