### PR TITLE
Shorten the CI name displayed in the GitHub UI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,4 @@
+name: ci
 on: [push, pull_request]
 jobs:
   gradle-android-test:

--- a/.github/workflows/detekt.yaml
+++ b/.github/workflows/detekt.yaml
@@ -1,3 +1,5 @@
+name: detekt
+
 on:
   pull_request:
     branches: [ master ]


### PR DESCRIPTION
Now it's short enough that both the file and the job names are visible
without clicking through to the main Actions page.

Before:
![before](https://user-images.githubusercontent.com/8304462/131159368-9f2229c5-5881-483a-9b26-d2d406da40fb.png)


After:
![after](https://user-images.githubusercontent.com/8304462/131159300-8d0a4290-ed9b-4810-b7b0-8ba73acf363d.png)
