### PR TITLE
Normalize the PublicKey fingerprint

### DIFF
--- a/domain/src/main/kotlin/tox/ToxTypes.kt
+++ b/domain/src/main/kotlin/tox/ToxTypes.kt
@@ -8,10 +8,7 @@ package ltd.evilcorp.domain.tox
 value class PublicKey(private val value: String) {
     fun bytes() = value.hexToBytes()
     fun string() = value
-    fun fingerprint(): String {
-        val shortId = value.take(8)
-        return "%s %s".format(shortId.take(4), shortId.takeLast(4))
-    }
+    fun fingerprint() = value.take(8)
 
     companion object {
         fun fromBytes(publicKey: ByteArray) = PublicKey(publicKey.bytesToHex())


### PR DESCRIPTION
In some places it's formated like `1234 1324` and in others `12341234`.
This commit modifies the PublicKey class to always return an unformatted
fingerprint in the format `12341234` that can later be prettified if
it's going somewhere user-visible.