### PR TITLE
Block starting multiple calls at once via the call notifications

### DIFF
--- a/atox/src/main/kotlin/ActionReceiver.kt
+++ b/atox/src/main/kotlin/ActionReceiver.kt
@@ -20,7 +20,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import ltd.evilcorp.atox.ui.NotificationHelper
 import ltd.evilcorp.core.vo.Contact
+import ltd.evilcorp.core.vo.UserStatus
 import ltd.evilcorp.domain.feature.CallManager
+import ltd.evilcorp.domain.feature.CallState
 import ltd.evilcorp.domain.feature.ChatManager
 import ltd.evilcorp.domain.feature.ContactManager
 import ltd.evilcorp.domain.tox.PublicKey
@@ -73,6 +75,18 @@ class ActionReceiver : BroadcastReceiver() {
                             Log.e(TAG, "Unable to get contact ${pk.fingerprint()} for call notification")
                             Contact(publicKey = pk.string(), name = pk.fingerprint())
                         }
+                    }
+
+                    if (callManager.inCall.value is CallState.InCall) {
+                        withContext(Dispatchers.Main) {
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.error_simultaneous_calls),
+                                Toast.LENGTH_LONG
+                            ).show()
+                            notificationHelper.showPendingCallNotification(UserStatus.Busy, contact)
+                        }
+                        return@launch
                     }
 
                     try {

--- a/atox/src/main/res/values/strings.xml
+++ b/atox/src/main/res/values/strings.xml
@@ -150,6 +150,7 @@
 
     <string name="call">Call</string>
     <string name="microphone_control">Microphone control</string>
+    <string name="error_simultaneous_calls">You can\'t be in multiple calls at the same time right now</string>
     <string name="end_call">End call</string>
     <string name="calls">Calls</string>
     <string name="ongoing_call">Ongoing call</string>


### PR DESCRIPTION
This will be rewritten to hide the accept button, but even then Android
tends to delay replacing notifications, so this is a good safeguard.