### PR TITLE
Disable Jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.caching=true
 org.gradle.parallel=true
 kotlin.code.style=official
 android.useAndroidX=true
-android.enableJetifier=true
+android.enableJetifier=false


### PR DESCRIPTION
It's no longer required, and we should not take any new dependencies on
legacy libraries.