### PR TITLE
Add a "mark as read" button to message notifications

### DIFF
--- a/atox/src/main/kotlin/ActionReceiver.kt
+++ b/atox/src/main/kotlin/ActionReceiver.kt
@@ -29,9 +29,9 @@ import ltd.evilcorp.domain.feature.ContactManager
 import ltd.evilcorp.domain.tox.PublicKey
 import ltd.evilcorp.domain.tox.Tox
 
-const val KEY_TEXT_REPLY = "text_reply"
-const val KEY_CONTACT_PK = "contact_pk"
-const val KEY_ACTION = "action"
+const val KEY_TEXT_REPLY = "key_text_reply"
+const val KEY_CONTACT_PK = "key_contact_pk"
+const val KEY_ACTION = "key_action"
 
 enum class Action {
     CallAccept,

--- a/atox/src/main/kotlin/ActionReceiver.kt
+++ b/atox/src/main/kotlin/ActionReceiver.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 aTox contributors
+// SPDX-FileCopyrightText: 2021-2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -32,6 +32,11 @@ import ltd.evilcorp.domain.tox.Tox
 const val KEY_TEXT_REPLY = "text_reply"
 const val KEY_CALL = "accept_or_reject_call"
 const val KEY_CONTACT_PK = "contact_pk"
+const val KEY_ACTION = "action"
+
+enum class Action {
+    MarkAsRead,
+}
 
 private const val TAG = "ActionReceiver"
 
@@ -118,6 +123,15 @@ class ActionReceiver : BroadcastReceiver() {
                 }
                 "ignore" -> callManager.removePendingCall(pk)
             }
+        }
+
+        when (intent.getSerializableExtra(KEY_ACTION) as Action?) {
+            Action.MarkAsRead -> scope.launch {
+                val pk = intent.getStringExtra(KEY_CONTACT_PK) ?: return@launch
+                contactRepository.setHasUnreadMessages(pk, false)
+                notificationHelper.dismissNotifications(PublicKey(pk))
+            }
+            null -> Log.e(TAG, "Missing action in intent $intent")
         }
     }
 }

--- a/atox/src/main/kotlin/ui/NotificationHelper.kt
+++ b/atox/src/main/kotlin/ui/NotificationHelper.kt
@@ -33,7 +33,6 @@ import javax.inject.Singleton
 import ltd.evilcorp.atox.Action
 import ltd.evilcorp.atox.ActionReceiver
 import ltd.evilcorp.atox.KEY_ACTION
-import ltd.evilcorp.atox.KEY_CALL
 import ltd.evilcorp.atox.KEY_CONTACT_PK
 import ltd.evilcorp.atox.KEY_TEXT_REPLY
 import ltd.evilcorp.atox.PendingIntentCompat
@@ -244,7 +243,7 @@ class NotificationHelper @Inject constructor(
                             "${contact.publicKey}_end_call".hashCode(),
                             Intent(context, ActionReceiver::class.java)
                                 .putExtra(KEY_CONTACT_PK, contact.publicKey)
-                                .putExtra(KEY_CALL, "end call"),
+                                .putExtra(KEY_ACTION, Action.CallEnd),
                             PendingIntent.FLAG_UPDATE_CURRENT
                         )
                     )
@@ -279,7 +278,7 @@ class NotificationHelper @Inject constructor(
                             "${c.publicKey}_accept_call".hashCode(),
                             Intent(context, ActionReceiver::class.java)
                                 .putExtra(KEY_CONTACT_PK, c.publicKey)
-                                .putExtra(KEY_CALL, "accept"),
+                                .putExtra(KEY_ACTION, Action.CallAccept),
                             PendingIntent.FLAG_UPDATE_CURRENT
                         )
                     )
@@ -296,7 +295,7 @@ class NotificationHelper @Inject constructor(
                             "${c.publicKey}_reject_call".hashCode(),
                             Intent(context, ActionReceiver::class.java)
                                 .putExtra(KEY_CONTACT_PK, c.publicKey)
-                                .putExtra(KEY_CALL, "reject"),
+                                .putExtra(KEY_ACTION, Action.CallReject),
                             PendingIntent.FLAG_UPDATE_CURRENT
                         )
                     )
@@ -308,7 +307,7 @@ class NotificationHelper @Inject constructor(
                     "${c.publicKey}_ignore_call".hashCode(),
                     Intent(context, ActionReceiver::class.java)
                         .putExtra(KEY_CONTACT_PK, c.publicKey)
-                        .putExtra(KEY_CALL, "ignore"),
+                        .putExtra(KEY_ACTION, Action.CallIgnore),
                     PendingIntent.FLAG_UPDATE_CURRENT
                 )
             )

--- a/atox/src/main/kotlin/ui/NotificationHelper.kt
+++ b/atox/src/main/kotlin/ui/NotificationHelper.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+// SPDX-FileCopyrightText: 2019-2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -30,7 +30,9 @@ import com.squareup.picasso.Picasso
 import com.squareup.picasso.Transformation
 import javax.inject.Inject
 import javax.inject.Singleton
+import ltd.evilcorp.atox.Action
 import ltd.evilcorp.atox.ActionReceiver
+import ltd.evilcorp.atox.KEY_ACTION
 import ltd.evilcorp.atox.KEY_CALL
 import ltd.evilcorp.atox.KEY_CONTACT_PK
 import ltd.evilcorp.atox.KEY_TEXT_REPLY
@@ -143,6 +145,20 @@ class NotificationHelper @Inject constructor(
                     .setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_REPLY)
                     .setAllowGeneratedReplies(true)
                     .build()
+            )
+            .addAction(
+                NotificationCompat.Action.Builder(
+                    null,
+                    context.getString(R.string.mark_as_read),
+                    PendingIntentCompat.getBroadcast(
+                        context,
+                        "${contact.publicKey}_mark_as_read".hashCode(),
+                        Intent(context, ActionReceiver::class.java)
+                            .putExtra(KEY_CONTACT_PK, contact.publicKey)
+                            .putExtra(KEY_ACTION, Action.MarkAsRead),
+                        PendingIntent.FLAG_UPDATE_CURRENT,
+                    )
+                ).setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_MARK_AS_READ).build()
             )
 
         if (outgoing) {

--- a/atox/src/main/res/values/strings.xml
+++ b/atox/src/main/res/values/strings.xml
@@ -184,4 +184,5 @@
     <string name="atox_profile_locked">aTox profile locked</string>
     <string name="tap_to_unlock_and_start_atox">Tap to unlock your profile and start aTox</string>
     <string name="share">Share</string>
+    <string name="mark_as_read">Mark as read</string>
 </resources>


### PR DESCRIPTION
I also replaced the ugly-ish stringly-typed notification -> action receiver connection with a nicer enum-based solution.