### PR TITLE
Only display the direct-reply notification button where it's supported

### DIFF
--- a/atox/src/main/kotlin/ui/NotificationHelper.kt
+++ b/atox/src/main/kotlin/ui/NotificationHelper.kt
@@ -115,13 +115,7 @@ class NotificationHelper @Inject constructor(
             .setSmallIcon(android.R.drawable.sym_action_chat)
             .setContentTitle(contact.name.ifEmpty { context.getText(R.string.contact_default_name) })
             .setContentText(message)
-            .setContentIntent(
-                NavDeepLinkBuilder(context)
-                    .setGraph(R.navigation.nav_graph)
-                    .setDestination(R.id.chatFragment)
-                    .setArguments(bundleOf(CONTACT_PUBLIC_KEY to contact.publicKey))
-                    .createPendingIntent()
-            )
+            .setContentIntent(deepLinkToChat(PublicKey(contact.publicKey)))
             .setAutoCancel(true)
 
         if (outgoing) {
@@ -268,13 +262,7 @@ class NotificationHelper @Inject constructor(
             .setSmallIcon(android.R.drawable.ic_menu_call)
             .setContentTitle(context.getString(R.string.incoming_call))
             .setContentText(context.getString(R.string.incoming_call_from, c.name))
-            .setContentIntent(
-                NavDeepLinkBuilder(context)
-                    .setGraph(R.navigation.nav_graph)
-                    .setDestination(R.id.chatFragment)
-                    .setArguments(bundleOf(CONTACT_PUBLIC_KEY to c.publicKey))
-                    .createPendingIntent()
-            )
+            .setContentIntent(deepLinkToChat(PublicKey(c.publicKey)))
             .addAction(
                 NotificationCompat.Action
                     .Builder(
@@ -327,4 +315,10 @@ class NotificationHelper @Inject constructor(
 
         notifier.notify(c.publicKey.hashCode() + CALL.hashCode(), notification)
     }
+
+    private fun deepLinkToChat(publicKey: PublicKey) = NavDeepLinkBuilder(context)
+        .setGraph(R.navigation.nav_graph)
+        .setDestination(R.id.chatFragment)
+        .setArguments(bundleOf(CONTACT_PUBLIC_KEY to publicKey.string()))
+        .createPendingIntent()
 }


### PR DESCRIPTION
I noticed this when messing around with chat bubbles. Very strange that Android Studio doesn't warn on it the way it does with other API-version violations. :(

The mark-as-read button had to be moved further down in the file in order to preserve the current order in the notification.

The chat deep-linking thing is just some minor cleanup. I needed the same 7 lines in a 3rd place when adding chat bubble support, so into a helper it goes.

I tested the button on API 21, and it definitely did not work there, so I'm just going to trust Google's tutorial on it and nuke it from the versions they say. :P