### PR TITLE
Fix direct reply intents falling through to other intent handling

### DIFF
--- a/atox/src/main/kotlin/ActionReceiver.kt
+++ b/atox/src/main/kotlin/ActionReceiver.kt
@@ -81,6 +81,7 @@ class ActionReceiver : BroadcastReceiver() {
                 }
                 chatManager.sendMessage(pk, input)
                 notificationHelper.showMessageNotification(Contact(pk.string(), tox.getName()), input, outgoing = true)
+                return
             }
         }
 


### PR DESCRIPTION
This was never intentional, but they were silently ignored until
317303358730ed56e10c175c908e08b3a990c6d5 which made them loudly ignored.