### PR TITLE
Trim the Romanian changelog to make it work on Google Play

### DIFF
--- a/fastlane/metadata/android/ro/changelogs/9.txt
+++ b/fastlane/metadata/android/ro/changelogs/9.txt
@@ -7,6 +7,5 @@ Suport pentru acceptarea automată a transferurilor de fișiere
 Caractere de avatar frumoase
 Ștergerea unui chat acum șterge și transferurile de fișiere asociate
 A fost reparată divizarea mesajelor cu caractere multi-byte
-Tradus în portugheză braziliană, rusă și germană.
 
 Changelog complet: https://github.com/evilcorpltd/aTox/releases


### PR DESCRIPTION
Google Play only gives us 500 characters per changelog, and the other translations seems like the least important thing in an already localized changelog.