### PR TITLE
Simplify the gradle-from-source CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,11 +68,11 @@ jobs:
     - name: Build tox4j
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
-        ./scripts/build-host -j$(nproc || sysctl -n hw.ncpu)
-        ./scripts/build-aarch64-linux-android -j$(nproc || sysctl -n hw.ncpu) release
-        ./scripts/build-arm-linux-androideabi -j$(nproc || sysctl -n hw.ncpu) release
-        ./scripts/build-i686-linux-android -j$(nproc || sysctl -n hw.ncpu) release
-        ./scripts/build-x86_64-linux-android -j$(nproc || sysctl -n hw.ncpu) release
+        ./scripts/build-host -j$(nproc)
+        ./scripts/build-aarch64-linux-android -j$(nproc) release
+        ./scripts/build-arm-linux-androideabi -j$(nproc) release
+        ./scripts/build-i686-linux-android -j$(nproc) release
+        ./scripts/build-x86_64-linux-android -j$(nproc) release
     - name: Build aTox
       run: ./gradlew build
     - name: Upload apk


### PR DESCRIPTION
Ubuntu supports nproc, so no fallback needed.