### PR TITLE
Refresh the Bazel cache whenever the Bazel build files change

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,8 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cache/bazel
-        key: bazel
+        key: bazel-${{ hashFiles('WORKSPACE', 'bazel/**') }}
+        restore-keys: bazel-
     - name: Install
       run: wget https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-linux-amd64 --output-document=bazelisk
     - name: Build


### PR DESCRIPTION
This should fix that the Bazel CI has gone from being one of the fastest CI jobs to being the slowest one. The cache is pretty much perfect, but we've never refreshed it since I set it up. Now the cache key will change whenever we update any of the Bazel build files, which should be often enough to keep the cache fresh enough that it will always run pretty quickly.

Time comparison from my fork:
With the new cache: succeeded 5 minutes ago in 2m 14s 
With the old cache: succeeded 14 hours ago in 14m 45s 