### PR TITLE
Bump the targetted NDK API to 19

### DIFF
--- a/scripts/build-arm-linux-androideabi
+++ b/scripts/build-arm-linux-androideabi
@@ -4,7 +4,7 @@ TARGET := armv7a-linux-androideabi
 
 include scripts/common.mk
 
-NDK_API := 16
+NDK_API := 19
 NDK_ARCH := arm
 VPX_ARCH := arm-linux-androideabi
 VPX_TARGET := armv7-android-gcc

--- a/scripts/build-i686-linux-android
+++ b/scripts/build-i686-linux-android
@@ -4,7 +4,7 @@ TARGET := i686-linux-android
 
 include scripts/common.mk
 
-NDK_API := 16
+NDK_API := 19
 NDK_ARCH := x86
 VPX_ARCH := $(TARGET)
 VPX_TARGET := x86-android-gcc


### PR DESCRIPTION
19 is Android KitKat which is the lowest version we support. 16 is
Jellybean which we haven't even tried to build aTox for.