### PR TITLE
Fix crash in handling of ending incoming calls

### DIFF
--- a/domain/src/main/kotlin/feature/CallManager.kt
+++ b/domain/src/main/kotlin/feature/CallManager.kt
@@ -81,7 +81,8 @@ class CallManager @Inject constructor(
     }
 
     fun endCall(publicKey: PublicKey) {
-        if ((inCall.value as CallState.InCall?)?.publicKey == publicKey) {
+        val state = inCall.value
+        if (state is CallState.InCall && state.publicKey == publicKey) {
             audioManager?.mode = AudioManager.MODE_NORMAL
             _inCall.value = CallState.NotInCall
         }


### PR DESCRIPTION
Introduced in f4979ffd87f0f70b0fa62ce4f411207cdf50b48b.

I thought `as` would cast to null if the type didn't match, but I was mistaken, and neither Android Studio nor the usual linter warned me, and it also wasn't detected in testing as it only happens if you're not in a call when hitting this case.

Found by @roihershberg.