### PR TITLE
Set up Windows and macOS CI again + publish tox4j artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,25 +31,36 @@ jobs:
     - uses: actions/checkout@v2
     - uses: gradle/wrapper-validation-action@v1
 
-  # TODO(robinlinden): Re-enable once the jvm-toxcore-* libraries are published somewhere.
-  # gradle:
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     max-parallel: 6
-  #     matrix:
-  #       os:
-  #       - ubuntu-20.04
-  #       - macOS-10.15
-  #       - windows-2019
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: actions/setup-java@v1
-  #     with:
-  #       java-version: 11
-  #   - name: Build and test
-  #     run: ./gradlew build
+  gradle:
+    runs-on: ${{ matrix.os }}
+    needs: tox4j
+    strategy:
+      max-parallel: 6
+      matrix:
+        os:
+        - ubuntu-20.04
+        - macOS-10.15
+        - windows-2019
+    steps:
+    - name: Download tox4j
+      uses: actions/download-artifact@v2
+      with:
+        name: tox4j
+        path: ~/.m2
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Build and test
+      run: ./gradlew build
+    - name: Upload apk
+      if: startsWith(matrix.os, 'ubuntu')
+      uses: actions/upload-artifact@v2
+      with:
+        name: atox-debug.apk
+        path: ./atox/build/outputs/apk/debug/atox-debug.apk
 
-  gradle-from-source:
+  tox4j:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
@@ -74,13 +85,11 @@ jobs:
         ./scripts/build-arm-linux-androideabi -j$(nproc) release
         ./scripts/build-i686-linux-android -j$(nproc) release
         ./scripts/build-x86_64-linux-android -j$(nproc) release
-    - name: Build aTox
-      run: ./gradlew build
-    - name: Upload apk
+    - name: Upload tox4j
       uses: actions/upload-artifact@v2
       with:
-        name: atox-debug.apk
-        path: ./atox/build/outputs/apk/debug/atox-debug.apk
+        name: tox4j
+        path: ~/.m2
 
   bazel:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: tox4j
     strategy:
-      max-parallel: 6
       matrix:
         os:
         - ubuntu-20.04
@@ -102,12 +101,10 @@ jobs:
         path: ~/.cache/bazel
         key: bazel-${{ hashFiles('WORKSPACE', 'bazel/**') }}
         restore-keys: bazel-
-    - name: Install
-      run: wget https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-linux-amd64 --output-document=bazelisk
     - name: Build
-      run: bazelisk build //...
+      run: bazel build //...
     - name: Test
-      run: bazelisk test //...
+      run: bazel test //...
 
   buildifier:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,20 +1,6 @@
 name: ci
 on: [push, pull_request]
 jobs:
-  gradle-android-test:
-    runs-on: macos-10.15
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v1
-      with:
-        java-version: 11
-    # TODO(robinlinden): Fix tests failing sporadically in CI.
-    - name: Test
-      uses: reactivecircus/android-emulator-runner@v2
-      with:
-        api-level: 29
-        script: ./gradlew connectedCheck -x :atox:connectedAndroidTest -x :domain:connectedAndroidTest || { adb logcat -d; exit 1; }
-
   ktlint:
     runs-on: ubuntu-20.04
     steps:
@@ -39,7 +25,7 @@ jobs:
       matrix:
         os:
         - ubuntu-20.04
-        - macOS-10.15
+        - macos-10.15
         - windows-2019
     steps:
     - name: Download tox4j
@@ -53,6 +39,12 @@ jobs:
         java-version: 11
     - name: Build and test
       run: ./gradlew build
+    - name: Run Android tests
+      if: startsWith(matrix.os, 'macos')
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: 29
+        script: ./gradlew connectedCheck -x :atox:connectedAndroidTest -x :domain:connectedAndroidTest || { adb logcat -d; exit 1; }
     - name: Upload apk
       if: startsWith(matrix.os, 'ubuntu')
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
This is all done in preparation of better androidTest coverage in CI, but this seems like a decent improvement and a good start.