### PR TITLE
Run all Android tests in CI again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,8 +42,9 @@ jobs:
       if: startsWith(matrix.os, 'macos')
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 29
-        script: ./gradlew connectedCheck -x :atox:connectedAndroidTest -x :domain:connectedAndroidTest || { adb logcat -d; exit 1; }
+        api-level: 31
+        arch: x86_64
+        script: ./gradlew connectedCheck || { adb logcat -d; exit 1; }
     - name: Upload apk
       if: startsWith(matrix.os, 'ubuntu')
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
Looks like they only fail on API 29 (due to oom) and only in CI. Locally they work fine with API 29. Increasing the amount of memory available (from unspecified to 2048MB, though the debug print showing memory allocated was still blank, so maybe it didn't work) in the emulator doesn't seem to fix the issue.

I edited the workflow in my repo to run these tests 10 times in a row, and I've rerun that workflow a few times with no failures, so this should be reasonably stable.

See:
```
Similar issue: https://github.com/google/android-fhir/issues/73
Similar issue: https://github.com/ReactiveCircus/android-emulator-runner/issues/131
Increasing the RAM size: https://github.com/ReactiveCircus/android-emulator-runner/pull/165/files
```