### PR TITLE
Use built-in NDK in GitHub runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,6 @@ jobs:
     - name: Build tox4j
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
-        unset ANDROID_NDK_HOME
         ./scripts/build-host -j$(nproc)
         ./scripts/build-aarch64-linux-android -j$(nproc) release
         ./scripts/build-arm-linux-androideabi -j$(nproc) release


### PR DESCRIPTION
We can now use the NDK provided by GitHub runners as patching the NDK and the overall libvpx build weirdness is no longer required after b61ead9083ea0a1f4cef261c3670f28b190731e9.