### PR TITLE
Fix the call ringtone not always being silenced when it should

### DIFF
--- a/atox/src/main/kotlin/ui/NotificationHelper.kt
+++ b/atox/src/main/kotlin/ui/NotificationHelper.kt
@@ -228,6 +228,7 @@ class NotificationHelper @Inject constructor(
         notifier.cancel(pk.string().hashCode() + CALL.hashCode())
 
     fun showOngoingCallNotification(contact: Contact) {
+        dismissCallNotification(PublicKey(contact.publicKey))
         val notificationBuilder = NotificationCompat.Builder(context, CALL)
             .setCategory(NotificationCompat.CATEGORY_CALL)
             .setSmallIcon(android.R.drawable.ic_menu_call)


### PR DESCRIPTION
Just swapping a notification out for a new one doesn't apply the new `setSilent` setting. :(