### PR TITLE
Update the Android Gradle plugin for Android Studio 2021.1.1 Patch 1

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,7 +2,7 @@ const val kotlinVersion = "1.6.10"
 
 object BuildPlugin {
     private object Version {
-        const val gradle = "7.1.0"
+        const val gradle = "7.1.1"
     }
 
     const val androidApplication = "com.android.application"


### PR DESCRIPTION
I would have done this a few days ago, but the updater was broken until today and would have required a full reinstall of Android Studio. :P

See: https://issuetracker.google.com/issues/217880228