### PR TITLE
Don't use LiveData outside of the GUI classes

### DIFF
--- a/atox/build.gradle.kts
+++ b/atox/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     implementation(AndroidX.preference)
 
     implementation(AndroidX.Lifecycle.livedataKtx)
+    implementation(AndroidX.Lifecycle.runtimeKtx)
     implementation(AndroidX.Lifecycle.service)
     implementation(AndroidX.Lifecycle.viewmodelKtx)
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -58,6 +58,7 @@ object AndroidX {
     object Lifecycle {
         private const val version = "2.4.0"
         const val livedataKtx = "androidx.lifecycle:lifecycle-livedata-ktx:$version"
+        const val runtimeKtx = "androidx.lifecycle:lifecycle-runtime-ktx:$version"
         const val service = "androidx.lifecycle:lifecycle-service:$version"
         const val viewmodelKtx = "androidx.lifecycle:lifecycle-viewmodel-ktx:$version"
     }


### PR DESCRIPTION
LiveData in general should only ever be used in GUIs. They always run on
the main thread, and they don't support things like suspension points.
This patch nukes the only instance of us using LiveData outside of the
GUI bits.