### PR TITLE
Fix crash when starting with a now-invalid proxy

### DIFF
--- a/atox/build.gradle.kts
+++ b/atox/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     implementation(AndroidX.preference)
 
     implementation(AndroidX.Lifecycle.livedataKtx)
+    implementation(AndroidX.Lifecycle.runtimeKtx)
     implementation(AndroidX.Lifecycle.service)
     implementation(AndroidX.Lifecycle.viewmodelKtx)
 

--- a/atox/src/main/kotlin/ui/settings/SettingsFragment.kt
+++ b/atox/src/main/kotlin/ui/settings/SettingsFragment.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+// SPDX-FileCopyrightText: 2019-2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -234,16 +234,22 @@ class SettingsFragment : BaseFragment<FragmentSettingsBinding>(FragmentSettingsB
             Toast.makeText(requireContext(), getString(R.string.password_updated), Toast.LENGTH_LONG).show()
         }
 
-        nospam.setText("%08X".format(vm.getNospam()))
-        nospam.doAfterTextChanged {
-            saveNospam.isEnabled =
-                nospam.text.length == 8 && nospam.text.toString().toUInt(16).toInt() != vm.getNospam()
-        }
-        saveNospam.isEnabled = false
-        saveNospam.setOnClickListener {
-            vm.setNospam(nospam.text.toString().toUInt(16).toInt())
+        if (vm.nospamAvailable()) {
+            nospam.setText("%08X".format(vm.getNospam()))
+            nospam.doAfterTextChanged {
+                saveNospam.isEnabled =
+                    nospam.text.length == 8 && nospam.text.toString().toUInt(16).toInt() != vm.getNospam()
+            }
             saveNospam.isEnabled = false
-            Toast.makeText(requireContext(), R.string.saved, Toast.LENGTH_LONG).show()
+            saveNospam.setOnClickListener {
+                vm.setNospam(nospam.text.toString().toUInt(16).toInt())
+                saveNospam.isEnabled = false
+                Toast.makeText(requireContext(), R.string.saved, Toast.LENGTH_LONG).show()
+            }
+        } else {
+            nospam.isEnabled = false
+            saveNospam.isEnabled = false
+            nospamExtraText.text = getString(R.string.pref_disabled_tox_error)
         }
 
         settingBootstrapNodes.adapter = ArrayAdapter.createFromResource(

--- a/atox/src/main/kotlin/ui/settings/SettingsViewModel.kt
+++ b/atox/src/main/kotlin/ui/settings/SettingsViewModel.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+// SPDX-FileCopyrightText: 2019-2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -59,6 +59,7 @@ class SettingsViewModel @Inject constructor(
     private val _committed = MutableLiveData<Boolean>().apply { value = false }
     val committed: LiveData<Boolean> get() = _committed
 
+    fun nospamAvailable(): Boolean = tox.started
     fun getNospam(): Int = tox.nospam
     fun setNospam(value: Int) {
         tox.nospam = value

--- a/atox/src/main/res/layout/fragment_settings.xml
+++ b/atox/src/main/res/layout/fragment_settings.xml
@@ -473,7 +473,9 @@
                                 app:layout_constraintEnd_toEndOf="parent"
                                 app:layout_constraintTop_toTopOf="parent"/>
                     </androidx.constraintlayout.widget.ConstraintLayout>
+                    <!-- This gets an ID so we can change the text when the nospam is unavailable. -->
                     <TextView
+                            android:id="@+id/nospam_extra_text"
                             style="@style/OptionItemText"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"

--- a/atox/src/main/res/values/strings.xml
+++ b/atox/src/main/res/values/strings.xml
@@ -159,6 +159,7 @@
     <string name="save">Save</string>
     <string name="pref_nospam">NoSpam</string>
     <string name="pref_nospam_description">Changing your NoSpam alters your Tox ID, meaning friend requests must be sent to the updated one</string>
+    <string name="pref_disabled_tox_error">Disabled due to an error starting Tox</string>
     <string name="saved">Saved</string>
     <string name="delete_message">Delete message</string>
     <string name="contact_default_name">Unknown</string>

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -58,6 +58,7 @@ object AndroidX {
     object Lifecycle {
         private const val version = "2.4.0"
         const val livedataKtx = "androidx.lifecycle:lifecycle-livedata-ktx:$version"
+        const val runtimeKtx = "androidx.lifecycle:lifecycle-runtime-ktx:$version"
         const val service = "androidx.lifecycle:lifecycle-service:$version"
         const val viewmodelKtx = "androidx.lifecycle:lifecycle-viewmodel-ktx:$version"
     }


### PR DESCRIPTION
This can happen if a DNS lookup is needed to find the proxy IP and
there's no internet available.