### PR TITLE
Add cache for gradle build in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,10 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 11
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        cache-read-only: ${{ github.ref != 'refs/heads/master' }}
     - name: Build and test
       run: ./gradlew build
     - name: Run Android tests


### PR DESCRIPTION
For comparison, the "Build and test" step in ubuntu-20.04 takes on average about 10m. It's now reduced to 49s with the cache (not counting the 20s of downloading the cache). This is of course not a trivial example as I didn't change anything that would result in recompilation but the point is that it functions like a local machine now.

The cache is configured to be read-only on branches other than master. So each PR invocation will be based on the cache in master. This is because the GitHub Cache is limited and saving a cache when you reached the limit will result in dropping another cache. If a lot of PR invocations will happen, there are good chances of dropping the cache of master which is not desired.