### PR TITLE
Update the Android Gradle plugin for Android Studio 2021.1.1 Patch 2

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,7 +2,7 @@ const val kotlinVersion = "1.6.10"
 
 object BuildPlugin {
     private object Version {
-        const val gradle = "7.1.1"
+        const val gradle = "7.1.2"
     }
 
     const val androidApplication = "com.android.application"


### PR DESCRIPTION
Nothing that obviously should affect us, but still. (And the updater works out of the gate this time!)
https://androidstudio.googleblog.com/2022/02/android-studio-bumblebee-202111-patch-2.html