### PR TITLE
Fix outgoing image previews not being invalidated correctly

### DIFF
--- a/atox/src/main/kotlin/ui/chat/ChatViewModel.kt
+++ b/atox/src/main/kotlin/ui/chat/ChatViewModel.kt
@@ -12,6 +12,7 @@ import android.widget.Toast
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
+import com.squareup.picasso.Picasso
 import java.io.File
 import java.io.FileInputStream
 import javax.inject.Inject
@@ -121,6 +122,9 @@ class ChatViewModel @Inject constructor(
     }
 
     fun createFt(file: Uri) = scope.launch {
+        // Make sure there's no stale cached image in Picasso.
+        // This happens if the user sends 2 different files with the same path (e.g. by overwriting one with the other.)
+        Picasso.get().invalidate(file)
         fileTransferManager.create(publicKey, file)
     }
 


### PR DESCRIPTION
This could sometimes lead to an incorrect outgoing image preview being
displayed, e.g. if the user sent a file from a path already cached in
Picasso.