### PR TITLE
Improve the reading of built-in bootstrap nodes

### DIFF
--- a/atox/src/main/kotlin/tox/BootstrapNodeRegistryImpl.kt
+++ b/atox/src/main/kotlin/tox/BootstrapNodeRegistryImpl.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 aTox contributors
+// SPDX-FileCopyrightText: 2021-2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -7,7 +7,6 @@ package ltd.evilcorp.atox.tox
 import android.content.Context
 import android.widget.Toast
 import java.io.File
-import java.nio.charset.StandardCharsets
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
@@ -36,11 +35,7 @@ class BootstrapNodeRegistryImpl @Inject constructor(
     override fun reset() {
         scope.launch(Dispatchers.IO) {
             val str = if (settings.bootstrapNodeSource == BootstrapNodeSource.BuiltIn) {
-                context.resources.openRawResource(R.raw.nodes).use {
-                    val bytes = ByteArray(it.available())
-                    it.read(bytes)
-                    String(bytes, StandardCharsets.UTF_8)
-                }
+                context.resources.openRawResource(R.raw.nodes).use { String(it.readBytes()) }
             } else {
                 File(context.filesDir, "user_nodes.json").readBytes().decodeToString()
             }


### PR DESCRIPTION
Not only is this less code, it also works on Android 4.3, and removes
the use of InputStream::available to get how many bytes to read,
something you're not really allowed to use available for anyway.