### PR TITLE
Update all actions used in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,8 +5,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v3
       with:
+        distribution: adopt
         java-version: 11
     - name: ktlint
       run: ./gradlew ktlint
@@ -28,13 +29,14 @@ jobs:
         - windows-2022
     steps:
     - name: Download tox4j
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: tox4j
         path: ~/.m2
     - uses: actions/checkout@v3
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v3
       with:
+        distribution: adopt
         java-version: 11
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
@@ -51,7 +53,7 @@ jobs:
         script: ./gradlew connectedCheck || { adb logcat -d; exit 1; }
     - name: Upload apk
       if: startsWith(matrix.os, 'ubuntu')
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: atox-debug.apk
         path: ./atox/build/outputs/apk/debug/atox-debug.apk
@@ -60,12 +62,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v3
       with:
+        distribution: adopt
         java-version: 11
     - name: Set up cache
       id: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.m2/repository/org/toktok
         key: from-src-${{ hashFiles('scripts/**') }}
@@ -81,7 +84,7 @@ jobs:
         ./scripts/build-i686-linux-android -j$(nproc) release
         ./scripts/build-x86_64-linux-android -j$(nproc) release
     - name: Upload tox4j
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: tox4j
         path: ~/.m2
@@ -90,8 +93,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v3
       with:
+        distribution: adopt
         java-version: 11
     - name: Set up Android
       run: |
@@ -100,7 +104,7 @@ jobs:
       env:
         NDK_VERSION: 22.1.7171670
     - name: Set up Bazel cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/bazel
         key: bazel-${{ hashFiles('WORKSPACE', 'bazel/**') }}

--- a/.github/workflows/detekt.yaml
+++ b/.github/workflows/detekt.yaml
@@ -13,7 +13,7 @@ jobs:
   detekt:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup
       run: |


### PR DESCRIPTION
This was partially done in #1018, but I missed the detekt.yaml, and I didn't realize I wasn't subscribed to release announcements for all the other actions, so here are the missing updates.