### PR TITLE
Update to Toxcore 0.2.18

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ espresso = "3.4.0"
 lifecycle = "2.4.1"
 navigation = "2.4.2"
 room = "2.4.2"
-tox4j-android = "0.2.17"
+tox4j-android = "0.2.18"
 tox4j-core = "0.2.3"
 
 [plugins]

--- a/scripts/android.mk
+++ b/scripts/android.mk
@@ -33,7 +33,6 @@ protobuf_CONFIGURE	:= --prefix=$(PREFIX) --host=$(TARGET) --with-sysroot=$(SYSRO
 libsodium_CONFIGURE	:= --prefix=$(PREFIX) --host=$(TARGET) --with-sysroot=$(SYSROOT) --disable-shared
 opus_CONFIGURE		:= --prefix=$(PREFIX) --host=$(TARGET) --with-sysroot=$(SYSROOT) --disable-shared
 libvpx_CONFIGURE	:= --prefix=$(PREFIX) --libc=$(SYSROOT) --target=$(VPX_TARGET) --disable-examples --disable-unit-tests --enable-pic
-msgpack_CONFIGURE	:= -DCMAKE_INSTALL_PREFIX:PATH=$(PREFIX) -DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE) -DANDROID_CPU_FEATURES=$(NDK_HOME)/sources/android/cpufeatures/cpu-features.c -DBUILD_SHARED_LIBS=OFF
 toxcore_CONFIGURE	:= -DCMAKE_INSTALL_PREFIX:PATH=$(PREFIX) -DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE) -DANDROID_CPU_FEATURES=$(NDK_HOME)/sources/android/cpufeatures/cpu-features.c -DENABLE_STATIC=ON -DENABLE_SHARED=OFF
 tox4j_CONFIGURE		:= -DCMAKE_INSTALL_PREFIX:PATH=$(PREFIX) -DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE) -DANDROID_CPU_FEATURES=$(NDK_HOME)/sources/android/cpufeatures/cpu-features.c
 

--- a/scripts/build-host
+++ b/scripts/build-host
@@ -41,7 +41,6 @@ protobuf_CONFIGURE	:= --prefix=$(PREFIX) --disable-shared
 libsodium_CONFIGURE	:= --prefix=$(PREFIX) --disable-shared
 opus_CONFIGURE		:= --prefix=$(PREFIX) --disable-shared
 libvpx_CONFIGURE	:= --prefix=$(PREFIX) --disable-examples --disable-unit-tests --enable-pic
-msgpack_CONFIGURE	:= -DCMAKE_INSTALL_PREFIX:PATH=$(PREFIX) -DBUILD_SHARED_LIBS=OFF
 toxcore_CONFIGURE	:= -DCMAKE_INSTALL_PREFIX:PATH=$(PREFIX) -DENABLE_STATIC=ON -DENABLE_SHARED=OFF
 tox4j_CONFIGURE		:= -DCMAKE_INSTALL_PREFIX:PATH=$(PREFIX)
 

--- a/scripts/dependencies.mk
+++ b/scripts/dependencies.mk
@@ -90,27 +90,13 @@ $(PREFIX)/protobuf.stamp: $(SRCDIR)/protobuf $(TOOLCHAIN_FILE) $(PROTOC)
 # toxcore
 
 $(SRCDIR)/toxcore:
-	git clone --depth=1 --branch=v0.2.17 https://github.com/TokTok/c-toxcore $@
+	git clone --depth=1 --branch=v0.2.18 --recursive https://github.com/TokTok/c-toxcore $@
 
 $(PREFIX)/toxcore.stamp: $(foreach f,$(shell cd $(SRCDIR)/toxcore && git ls-files),$(SRCDIR)/toxcore/$f)
-$(PREFIX)/toxcore.stamp: $(SRCDIR)/toxcore $(TOOLCHAIN_FILE) $(foreach i,libsodium msgpack opus libvpx,$(PREFIX)/$i.stamp)
+$(PREFIX)/toxcore.stamp: $(SRCDIR)/toxcore $(TOOLCHAIN_FILE) $(foreach i,libsodium opus libvpx,$(PREFIX)/$i.stamp)
 	@$(PRE_RULE)
 	mkdir -p $(BUILDDIR)/$(notdir $<)
 	cd $(BUILDDIR)/$(notdir $<) && cmake $(SRCDIR)/$(notdir $<) $($(notdir $<)_CONFIGURE) -DMUST_BUILD_TOXAV=ON -DBOOTSTRAP_DAEMON=OFF
-	$(MAKE) -C $(BUILDDIR)/$(notdir $<) install
-	mkdir -p $(@D) && touch $@
-	@$(POST_RULE)
-
-#############################################################################
-# msgpack
-
-$(SRCDIR)/msgpack:
-	git clone --depth=1 --branch=c-4.0.0 https://github.com/msgpack/msgpack-c $@
-
-$(PREFIX)/msgpack.stamp: $(SRCDIR)/msgpack $(TOOLCHAIN_FILE)
-	@$(PRE_RULE)
-	mkdir -p $(BUILDDIR)/$(notdir $<)
-	cd $(BUILDDIR)/$(notdir $<) && cmake $(SRCDIR)/$(notdir $<) $($(notdir $<)_CONFIGURE)
 	$(MAKE) -C $(BUILDDIR)/$(notdir $<) install
 	mkdir -p $(@D) && touch $@
 	@$(POST_RULE)


### PR DESCRIPTION
toktok/c-toxcore replaced msgpack with cmp (as a git submodule) between 0.2.17 and 0.2.18.