### PR TITLE
Fix crash when exporting tox save

### DIFF
--- a/atox/src/main/res/values/strings.xml
+++ b/atox/src/main/res/values/strings.xml
@@ -186,4 +186,5 @@
     <string name="tap_to_unlock_and_start_atox">Tap to unlock your profile and start aTox</string>
     <string name="share">Share</string>
     <string name="mark_as_read">Mark as read</string>
+    <string name="file_not_found">File not found</string>
 </resources>


### PR DESCRIPTION
Fix crash when exporting tox save and the file doesn't exist. This is due to bad implementation of the DocumentsUI app and can be reproduced by:

1. Exporting the Tox save to some file
2. Clicking on export once again
3. Clicking in the file manager on the previously exported Tox save
4. Going to another file manager and deleting the previously exported Tox save
5. Returning back to the app and clicking SAVE
6. Clicking OK on the dialog of the overwrite