### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,6 +68,17 @@ jobs:
       with:
         path: ~/.m2/repository/org/toktok
         key: from-src-${{ hashFiles('scripts/**') }}
+    # TODO(robinlinden): Update NDK.
+    - name: Set up NDK
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        # https://github.com/actions/virtual-environments/issues/5595
+        ANDROID_ROOT="/usr/local/lib/android"
+        ANDROID_SDK_ROOT="${ANDROID_ROOT}/sdk"
+        SDKMANAGER="${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager"
+        echo "y" | $SDKMANAGER "ndk;21.4.7075529"
+        export ANDROID_NDK="${ANDROID_SDK_ROOT}/ndk-bundle"
+        ln -sfn $ANDROID_SDK_ROOT/ndk/21.4.7075529 $ANDROID_NDK
     - name: Install tox4j dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       run: sudo apt-get update && sudo apt install yasm


### PR DESCRIPTION
GitHub switched the default NDK from 21 to 23, and it doesn't seem to
work out-of-the-box for us, so let's pin it to 21 for now.