### PR TITLE
Simplify share dialog

### DIFF
--- a/atox/src/main/kotlin/ui/ReceiveShareDialogFragment.kt
+++ b/atox/src/main/kotlin/ui/ReceiveShareDialogFragment.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 aTox contributors
+// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -6,10 +6,13 @@ package ltd.evilcorp.atox.ui
 
 import android.app.Dialog
 import android.content.Context
+import android.content.DialogInterface
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.view.Window
+import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.LiveData
 import ltd.evilcorp.atox.R
 import ltd.evilcorp.atox.databinding.DialogReceiveShareBinding
 import ltd.evilcorp.atox.truncated
@@ -18,9 +21,31 @@ import ltd.evilcorp.core.vo.Contact
 
 private const val SHARE_TEXT_PREVIEW_LENGTH = 128
 
-class ReceiveShareDialog(
+class ReceiveShareDialogFragment(
+    private val contacts: LiveData<List<Contact>>,
+    private val sharePreview: String,
+    private val onContactSelected: (Contact) -> Unit,
+    private val onDialogDismissed: () -> Unit,
+) : DialogFragment() {
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = ReceiveShareDialog(requireContext(), sharePreview, onContactSelected)
+        contacts.observe(this) { dialog.setContacts(it.sortedByDescending(::contactListSorter)) }
+        return dialog
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        onDialogDismissed()
+    }
+
+    override fun onCancel(dialog: DialogInterface) {
+        super.onCancel(dialog)
+        onDialogDismissed()
+    }
+}
+
+private class ReceiveShareDialog(
     ctx: Context,
-    private var contacts: List<Contact>,
     private val sharePreview: String,
     private val contactSelectedFunc: (Contact) -> Unit,
 ) : Dialog(ctx, R.style.DialogSlideAnimation) {
@@ -37,10 +62,7 @@ class ReceiveShareDialog(
         binding.sharingText.text = String.format("%s", sharePreview.truncated(SHARE_TEXT_PREVIEW_LENGTH))
 
         binding.contacts.let {
-            it.adapter = ContactAdapter(layoutInflater, context).apply {
-                contacts = this@ReceiveShareDialog.contacts
-                notifyDataSetChanged()
-            }
+            it.adapter = ContactAdapter(layoutInflater, context)
             it.setOnItemClickListener { _, _, position, _ ->
                 val contact = binding.contacts.getItemAtPosition(position) as Contact
                 contactSelectedFunc(contact)
@@ -50,9 +72,8 @@ class ReceiveShareDialog(
     }
 
     fun setContacts(contacts: List<Contact>) {
-        this.contacts = contacts
         (binding.contacts.adapter as ContactAdapter?)?.let {
-            it.contacts = this.contacts
+            it.contacts = contacts
             it.notifyDataSetChanged()
         }
     }

--- a/atox/src/main/kotlin/ui/Util.kt
+++ b/atox/src/main/kotlin/ui/Util.kt
@@ -1,4 +1,5 @@
-// SPDX-FileCopyrightText: 2019-2022 aTox contributors
+// SPDX-FileCopyrightText: 2019-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -9,6 +10,8 @@ import android.content.res.Resources
 import android.util.TypedValue
 import androidx.core.content.ContextCompat
 import ltd.evilcorp.atox.R
+import ltd.evilcorp.core.vo.ConnectionStatus
+import ltd.evilcorp.core.vo.Contact
 import ltd.evilcorp.core.vo.UserStatus
 
 internal fun colorFromStatus(context: Context, status: UserStatus) = when (status) {
@@ -26,4 +29,10 @@ internal value class Px(val px: Int) : Size
 internal value class Dp(val dp: Float) : Size {
     fun asPx(res: Resources): Px =
         Px(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp, res.displayMetrics).toInt())
+}
+
+internal fun contactListSorter(contact: Contact) = when {
+    contact.lastMessage != 0L -> contact.lastMessage
+    contact.connectionStatus == ConnectionStatus.None -> -1000L
+    else -> -contact.status.ordinal.toLong()
 }

--- a/atox/src/main/kotlin/ui/contactlist/ContactListFragment.kt
+++ b/atox/src/main/kotlin/ui/contactlist/ContactListFragment.kt
@@ -1,4 +1,5 @@
-// SPDX-FileCopyrightText: 2019-2022 aTox contributors
+// SPDX-FileCopyrightText: 2019-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -37,7 +38,7 @@ import ltd.evilcorp.atox.databinding.FriendRequestItemBinding
 import ltd.evilcorp.atox.databinding.NavHeaderContactListBinding
 import ltd.evilcorp.atox.truncated
 import ltd.evilcorp.atox.ui.BaseFragment
-import ltd.evilcorp.atox.ui.ReceiveShareDialog
+import ltd.evilcorp.atox.ui.ReceiveShareDialogFragment
 import ltd.evilcorp.atox.ui.chat.CONTACT_PUBLIC_KEY
 import ltd.evilcorp.atox.ui.colorFromStatus
 import ltd.evilcorp.atox.ui.contactListSorter
@@ -67,7 +68,6 @@ class ContactListFragment :
 
     private var backupFileNameHint = "something_is_broken.tox"
 
-    private var shareDialog: ReceiveShareDialog? = null
     private var passwordDialog: AlertDialog? = null
 
     private val exportToxSaveLauncher = registerForActivityResult(ActivityResultContracts.CreateDocument()) { dest ->
@@ -143,8 +143,6 @@ class ContactListFragment :
             } else {
                 View.GONE
             }
-
-            shareDialog?.setContacts(contactAdapter.contacts)
         }
 
         contactList.setOnItemClickListener { _, _, position, _ ->
@@ -177,19 +175,17 @@ class ContactListFragment :
         }
 
         arguments?.getString(ARG_SHARE)?.let { share ->
-            shareDialog = ReceiveShareDialog(
-                requireContext(),
-                (binding.contactList.adapter as ContactAdapter).contacts,
+            ReceiveShareDialogFragment(
+                viewModel.contacts,
                 share,
-            ) {
-                viewModel.onShareText(share, it)
-                openChat(it)
-            }
-            shareDialog?.setOnDismissListener {
-                shareDialog = null
-                arguments?.remove(ARG_SHARE)
-            }
-            shareDialog?.show()
+                onContactSelected = {
+                    viewModel.onShareText(share, it)
+                    openChat(it)
+                },
+                onDialogDismissed = {
+                    arguments?.remove(ARG_SHARE)
+                },
+            ).show(childFragmentManager, null)
         }
     }
 

--- a/atox/src/main/kotlin/ui/contactlist/ContactListFragment.kt
+++ b/atox/src/main/kotlin/ui/contactlist/ContactListFragment.kt
@@ -40,6 +40,7 @@ import ltd.evilcorp.atox.ui.BaseFragment
 import ltd.evilcorp.atox.ui.ReceiveShareDialog
 import ltd.evilcorp.atox.ui.chat.CONTACT_PUBLIC_KEY
 import ltd.evilcorp.atox.ui.colorFromStatus
+import ltd.evilcorp.atox.ui.contactListSorter
 import ltd.evilcorp.atox.ui.friendrequest.FRIEND_REQUEST_PUBLIC_KEY
 import ltd.evilcorp.atox.vmFactory
 import ltd.evilcorp.core.vo.ConnectionStatus
@@ -134,13 +135,7 @@ class ContactListFragment :
         }
 
         viewModel.contacts.observe(viewLifecycleOwner) { contacts ->
-            contactAdapter.contacts = contacts.sortedByDescending { contact ->
-                when {
-                    contact.lastMessage != 0L -> contact.lastMessage
-                    contact.connectionStatus == ConnectionStatus.None -> -1000L
-                    else -> -contact.status.ordinal.toLong()
-                }
-            }
+            contactAdapter.contacts = contacts.sortedByDescending(::contactListSorter)
             contactAdapter.notifyDataSetChanged()
 
             noContactsCallToAction.visibility = if (contactAdapter.isEmpty) {


### PR DESCRIPTION
This is being done in preparation of adding support for receiving non-text shares.

Tox requires contacts to be online when initiating file transfers, and aTox does not yet support faux-offline file transfers, so this will allow us to filter out offline contacts in a nice way depending on what we're sharing.

Part of #699 