### PR TITLE
Nuke MockK

### DIFF
--- a/atox/build.gradle.kts
+++ b/atox/build.gradle.kts
@@ -92,6 +92,5 @@ dependencies {
     androidTestImplementation(libs.test.espresso.core)
     androidTestImplementation(libs.test.espresso.contrib)
     androidTestImplementation(libs.test.junit.ext)
-    androidTestImplementation(libs.test.mockk)
     kaptAndroidTest(libs.google.dagger.compiler)
 }

--- a/atox/src/androidTest/kotlin/IntegrationTest.kt
+++ b/atox/src/androidTest/kotlin/IntegrationTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020-2021 aTox contributors
+// SPDX-FileCopyrightText: 2020-2022 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -25,12 +25,15 @@ import dagger.Module
 import dagger.Provides
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import ltd.evilcorp.atox.di.AndroidModule
 import ltd.evilcorp.atox.di.AppComponent
-import ltd.evilcorp.atox.di.AppModule
 import ltd.evilcorp.atox.di.DaoModule
 import ltd.evilcorp.atox.di.ViewModelModule
+import ltd.evilcorp.atox.tox.BootstrapNodeRegistryImpl
 import ltd.evilcorp.core.db.Database
+import ltd.evilcorp.domain.tox.BootstrapNodeRegistry
 import ltd.evilcorp.domain.tox.PublicKey
 import ltd.evilcorp.domain.tox.SaveManager
 import org.hamcrest.core.AllOf.allOf
@@ -62,12 +65,17 @@ class TestModule {
         every { load(PublicKey("workaround")) } returns null
         // Am I using mockk wrong or something? `every { save(any(), any() }` crashes.
     }
+
+    @Provides
+    fun provideBootstrapNodeRegistry(nodeRegistry: BootstrapNodeRegistryImpl): BootstrapNodeRegistry = nodeRegistry
+
+    @Provides
+    fun provideCoroutineScope(): CoroutineScope = CoroutineScope(Dispatchers.Default)
 }
 
 @Singleton
 @Component(
     modules = [
-        AppModule::class,
         AndroidModule::class,
         TestModule::class,
         DaoModule::class,

--- a/atox/src/androidTest/kotlin/IntegrationTest.kt
+++ b/atox/src/androidTest/kotlin/IntegrationTest.kt
@@ -23,8 +23,6 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
 import dagger.Provides
-import io.mockk.every
-import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import ltd.evilcorp.atox.di.AndroidModule
@@ -52,6 +50,14 @@ class InjectedActivityTestRule<T : Activity>(
     }
 }
 
+class FakeSaveManager : SaveManager {
+    override fun list(): List<String> = listOf()
+    override fun load(pk: PublicKey): ByteArray? = null
+    override fun save(pk: PublicKey, saveData: ByteArray) {
+        // Do nothing.
+    }
+}
+
 @Module
 class TestModule {
     @Singleton
@@ -60,17 +66,13 @@ class TestModule {
         Room.inMemoryDatabaseBuilder(appContext, Database::class.java).build()
 
     @Provides
-    fun provideSaveManager(): SaveManager = mockk(relaxUnitFun = true) {
-        every { list() } returns listOf("workaround") // mockk crashes w/ `listOf()`.
-        every { load(PublicKey("workaround")) } returns null
-        // Am I using mockk wrong or something? `every { save(any(), any() }` crashes.
-    }
-
-    @Provides
     fun provideBootstrapNodeRegistry(nodeRegistry: BootstrapNodeRegistryImpl): BootstrapNodeRegistry = nodeRegistry
 
     @Provides
     fun provideCoroutineScope(): CoroutineScope = CoroutineScope(Dispatchers.Default)
+
+    @Provides
+    fun provideSaveManager(): SaveManager = FakeSaveManager()
 }
 
 @Singleton

--- a/atox/src/main/kotlin/di/AppModule.kt
+++ b/atox/src/main/kotlin/di/AppModule.kt
@@ -1,15 +1,18 @@
-// SPDX-FileCopyrightText: 2021 aTox contributors
+// SPDX-FileCopyrightText: 2021-2022 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
 package ltd.evilcorp.atox.di
 
+import android.content.Context
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import ltd.evilcorp.atox.tox.BootstrapNodeRegistryImpl
+import ltd.evilcorp.domain.tox.AndroidSaveManager
 import ltd.evilcorp.domain.tox.BootstrapNodeRegistry
+import ltd.evilcorp.domain.tox.SaveManager
 
 @Module
 class AppModule {
@@ -18,4 +21,7 @@ class AppModule {
 
     @Provides
     fun provideCoroutineScope(): CoroutineScope = CoroutineScope(Dispatchers.Default)
+
+    @Provides
+    fun provideSaveManager(ctx: Context): SaveManager = AndroidSaveManager(ctx)
 }

--- a/core/src/main/kotlin/repository/ContactRepository.kt
+++ b/core/src/main/kotlin/repository/ContactRepository.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class ContactRepository @Inject internal constructor(
+class ContactRepository @Inject constructor(
     private val dao: ContactDao,
 ) {
     fun exists(publicKey: String): Boolean = dao.exists(publicKey)

--- a/core/src/main/kotlin/repository/UserRepository.kt
+++ b/core/src/main/kotlin/repository/UserRepository.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class UserRepository @Inject internal constructor(
+class UserRepository @Inject constructor(
     private val userDao: UserDao,
 ) {
     fun exists(publicKey: String): Boolean =

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -92,5 +92,4 @@ dependencies {
         // Conflicts with a lot of things due to having embedded "byte buddy" instead of depending on it.A
         exclude("org.jetbrains.kotlinx", "kotlinx-coroutines-debug")
     }
-    androidTestImplementation(libs.test.mockk)
 }

--- a/domain/src/androidTest/kotlin/tox/ToxTest.kt
+++ b/domain/src/androidTest/kotlin/tox/ToxTest.kt
@@ -1,30 +1,54 @@
-// SPDX-FileCopyrightText: 2020-2022 aTox contributors
+// SPDX-FileCopyrightText: 2020-2022 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
 package ltd.evilcorp.domain.tox
 
+import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.mockk.mockk
+import androidx.test.platform.app.InstrumentationRegistry
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import ltd.evilcorp.core.db.Database
+import ltd.evilcorp.core.repository.ContactRepository
+import ltd.evilcorp.core.repository.UserRepository
 import org.junit.Test
 import org.junit.runner.RunWith
+
+class FakeBootstrapNodeRegistry : BootstrapNodeRegistry {
+    override fun get(n: Int): List<BootstrapNode> = listOf()
+    override fun reset() {
+        // Do nothing.
+    }
+}
+
+class FakeSaveManager : SaveManager {
+    override fun list(): List<String> = listOf()
+    override fun load(pk: PublicKey): ByteArray? = null
+    override fun save(pk: PublicKey, saveData: ByteArray) {
+        // Do nothing.
+    }
+}
 
 @RunWith(AndroidJUnit4::class)
 class ToxTest {
     @ExperimentalCoroutinesApi
     @Test
     fun quitting_does_not_crash() = runTest {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val db = Room.inMemoryDatabaseBuilder(instrumentation.context, Database::class.java).build()
+        val userRepository = UserRepository(db.userDao())
+        val contactRepository = ContactRepository(db.contactDao())
+
         repeat(10) {
             val tox = Tox(
                 TestScope(),
-                mockk(relaxUnitFun = true),
-                mockk(relaxUnitFun = true),
-                mockk(relaxUnitFun = true),
-                mockk(),
+                contactRepository,
+                userRepository,
+                FakeSaveManager(),
+                FakeBootstrapNodeRegistry(),
             ).apply { isBootstrapNeeded = false }
             tox.start(SaveOptions(null, false, ProxyType.None, "", 0), null, ToxEventListener(), ToxAvEventListener())
             delay(25)

--- a/domain/src/main/kotlin/tox/SaveManager.kt
+++ b/domain/src/main/kotlin/tox/SaveManager.kt
@@ -11,9 +11,15 @@ import androidx.core.util.writeBytes
 import java.io.File
 import javax.inject.Inject
 
-private const val TAG = "SaveManager"
+private const val TAG = "AndroidSaveManager"
 
-class SaveManager @Inject constructor(val context: Context) {
+interface SaveManager {
+    fun list(): List<String>
+    fun save(pk: PublicKey, saveData: ByteArray)
+    fun load(pk: PublicKey): ByteArray?
+}
+
+class AndroidSaveManager @Inject constructor(val context: Context) : SaveManager {
     private val saveDir = context.filesDir
 
     init {
@@ -22,16 +28,16 @@ class SaveManager @Inject constructor(val context: Context) {
         }
     }
 
-    fun list(): List<String> = saveDir.listFiles()?.let { saves ->
+    override fun list(): List<String> = saveDir.listFiles()?.let { saves ->
         saves.filter { it.extension == "tox" }.map { it.nameWithoutExtension }
     } ?: listOf()
 
-    fun save(publicKey: PublicKey, saveData: ByteArray) = AtomicFile(File("$saveDir/${publicKey.string()}.tox")).run {
+    override fun save(pk: PublicKey, saveData: ByteArray) = AtomicFile(File("$saveDir/${pk.string()}.tox")).run {
         Log.i(TAG, "Saving profile to $baseFile")
         writeBytes(saveData)
     }
 
-    fun load(publicKey: PublicKey): ByteArray? = tryReadBytes(File(pathTo(publicKey)))
+    override fun load(pk: PublicKey): ByteArray? = tryReadBytes(File(pathTo(pk)))
 
     private fun tryReadBytes(saveFile: File): ByteArray? =
         if (saveFile.exists()) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -80,7 +80,6 @@ test-espresso-contrib = { module = "androidx.test.espresso:espresso-contrib", ve
 test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
 test-junit-core = "junit:junit:4.13.2"
 test-junit-ext = "androidx.test.ext:junit:1.1.3"
-test-mockk = "io.mockk:mockk-android:1.11.0"
 test-rules = { module = "androidx.test:rules", version.ref = "androidx-test" }
 test-runner = { module = "androidx.test:runner", version.ref = "androidx-test" }
 


### PR DESCRIPTION
It was mostly unused, and where we used it we didn't use it for mocking. We haven't been able to update it for ages as they dropped support for anything less than API 21, and unless you create interfaces and mock the normal way, the tests don't run on API-levels < 28.