### PR TITLE
Migrate from deprecated constructor to using explicit wildcard mime type

### DIFF
--- a/atox/src/main/kotlin/ui/chat/ChatFragment.kt
+++ b/atox/src/main/kotlin/ui/chat/ChatFragment.kt
@@ -79,7 +79,7 @@ class ChatFragment : BaseFragment<FragmentChatBinding>(FragmentChatBinding::infl
             viewModel.backupHistory(contactPubKey, dest)
         }
 
-    private val exportFtLauncher = registerForActivityResult(ActivityResultContracts.CreateDocument()) { dest ->
+    private val exportFtLauncher = registerForActivityResult(ActivityResultContracts.CreateDocument("*/*")) { dest ->
         if (dest == null) return@registerForActivityResult
         viewModel.exportFt(selectedFt, dest)
     }

--- a/atox/src/main/kotlin/ui/contactlist/ContactListFragment.kt
+++ b/atox/src/main/kotlin/ui/contactlist/ContactListFragment.kt
@@ -70,10 +70,11 @@ class ContactListFragment :
 
     private var passwordDialog: AlertDialog? = null
 
-    private val exportToxSaveLauncher = registerForActivityResult(ActivityResultContracts.CreateDocument()) { dest ->
-        if (dest == null) return@registerForActivityResult
-        viewModel.saveToxBackupTo(dest)
-    }
+    private val exportToxSaveLauncher =
+        registerForActivityResult(ActivityResultContracts.CreateDocument("*/*")) { dest ->
+            if (dest == null) return@registerForActivityResult
+            viewModel.saveToxBackupTo(dest)
+        }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         val v = super.onCreateView(inflater, container, savedInstanceState)


### PR DESCRIPTION
Exporting a file transfer will have a different mime type depending on what the transfer contained, and Tox saves are binary blobs.