### PR TITLE
Update to v2 of github/codeql-action/upload-sarif

### DIFF
--- a/.github/workflows/detekt.yaml
+++ b/.github/workflows/detekt.yaml
@@ -33,7 +33,7 @@ jobs:
           --base-path ${{ github.workspace }} \
           --report sarif:${{ github.workspace }}/detekt.sarif.json
 
-    - uses: github/codeql-action/upload-sarif@v1
+    - uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: ${{ github.workspace }}/detekt.sarif.json
         checkout_path: ${{ github.workspace }}


### PR DESCRIPTION
v1 will be deprecated in December and receive no further updates after that.

https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/