### PR TITLE
Disable broken InvalidPackageDeclaration rule in detekt

### DIFF
--- a/.github/workflows/detekt.yaml
+++ b/.github/workflows/detekt.yaml
@@ -29,6 +29,8 @@ jobs:
       continue-on-error: true
       run: |
         java -jar detekt \
+          --build-upon-default-config \
+          --config detekt.yml \
           --input ${{ github.workspace }} \
           --base-path ${{ github.workspace }} \
           --report sarif:${{ github.workspace }}/detekt.sarif.json

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,0 +1,3 @@
+naming:
+  InvalidPackageDeclaration:
+    active: false


### PR DESCRIPTION
We set a package prefix in the Gradle files so we don't have to have that unreasonably deep folder structure most Gradle projects do, and detekt doesn't seem to understand that. There are some configuration options to do with ignoring a part of a package, but setting that up in a multi-module project seems like too much work when ktlint already checks this.