### PR TITLE
Disable Detekt warning about too many returns in a function

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -5,3 +5,7 @@ naming:
 empty-blocks:
   EmptyFunctionBlock:
     ignoreOverridden: true
+
+style:
+  ReturnCount:
+    active: false


### PR DESCRIPTION
We use early returns a lot to reduce nesting.