### PR TITLE
Drop gradle-versions-plugin in favour of the builtin checker

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
-    alias(libs.plugins.versions)
     alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.androidApplication) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,6 @@ tox4j-android = "0.2.18"
 tox4j-core = "0.2.3"
 
 [plugins]
-versions = "com.github.ben-manes.versions:0.47.0"
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinKsp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 androidApplication = { id = "com.android.application", version.ref = "android-plugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ dagger = "2.48"
 espresso = "3.5.1"
 jackson = "2.15.2"
 lifecycle = "2.6.2"
-navigation = "2.6.0" # 2.7.2 requires API 34.
+navigation = "2.6.0" # 2.7.4 requires API 34.
 room = "2.5.2"
 tox4j-android = "0.2.18"
 tox4j-core = "0.2.3"
@@ -23,7 +23,7 @@ androidApplication = { id = "com.android.application", version.ref = "android-pl
 androidLibrary = { id = "com.android.library", version.ref = "android-plugin" }
 
 [libraries]
-androidx-activity = "androidx.activity:activity:1.7.2"
+androidx-activity = "androidx.activity:activity:1.7.2" # 1.8.0 requires API 34.
 androidx-appcompat = "androidx.appcompat:appcompat:1.6.1"
 androidx-constraintlayout = "androidx.constraintlayout:constraintlayout:2.1.4"
 androidx-core-ktx = "androidx.core:core-ktx:1.10.1" # 1.12.0 requires API 34.
@@ -44,7 +44,7 @@ androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 androidx-room-testing = { module = "androidx.room:room-testing", version.ref = "room" }
 
-google-android-material = "com.google.android.material:material:1.9.0"
+google-android-material = "com.google.android.material:material:1.9.0" # 1.10.0 requires API 34
 google-dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }
 google-dagger-core = { module = "com.google.dagger:dagger", version.ref = "dagger" }
 


### PR DESCRIPTION
gradle-versions-plugin appears to no longer work, but that's fine
because whatever you get by default w/ the newer Android Studio and
Gradle seems to work well, even with the version catalog stuff we're
using.