### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,11 @@ jobs:
     - name: Install tox4j dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       run: sudo apt-get update && sudo apt install yasm
+    - name: Work around jvm-toxcore-c not building w/ libstdc++-13
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-jammy.list
+        sudo apt-get update
+        sudo apt-get install --allow-downgrades libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04
     - name: Build tox4j
       if: steps.cache.outputs.cache-hit != 'true'
       run: |


### PR DESCRIPTION
Once https://github.com/TokTok/jvm-toxcore-c/pull/107 is merged, this can be reverted and we can build with libstdc++13 instead.