### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: ci
-on: [push, pull_request]
+
+on:
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   ktlint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,7 +116,6 @@ jobs:
       with:
         path: ~/.cache/bazel
         key: bazel-${{ hashFiles('WORKSPACE', 'bazel/**') }}
-        restore-keys: bazel-
     - run: bazel test //...
 
   buildifier:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,7 +115,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.cache/bazel
-        key: bazel-${{ hashFiles('WORKSPACE', 'bazel/**') }}
+        key: bazel-${{ hashFiles('.bazelversion', 'WORKSPACE', 'bazel/**') }}
     - run: bazel test //...
 
   buildifier:


### PR DESCRIPTION
* Stop running CI at least twice on every commit
* Drop the Bazel cache when it's unlikely to be helpful