### PR TITLE
Fix possible ANR when e.g. leaving the chat view during bootstrapping

### DIFF
--- a/domain/src/main/kotlin/feature/ChatManager.kt
+++ b/domain/src/main/kotlin/feature/ChatManager.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+// SPDX-FileCopyrightText: 2019-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -108,5 +108,7 @@ class ChatManager @Inject constructor(
         contactRepository.setLastMessage(publicKey.string(), 0)
     }
 
-    fun setTyping(publicKey: PublicKey, typing: Boolean) = tox.setTyping(publicKey, typing)
+    fun setTyping(publicKey: PublicKey, typing: Boolean) = scope.launch {
+        tox.setTyping(publicKey, typing)
+    }
 }


### PR DESCRIPTION
This triggers a synchronous call from the main thread into Tox to change
the selfTyping status which will try to take the same mutex that
bootstrapping might be holding during a call into things that do
networking.