### PR TITLE
Cap the number of active friend requests to 32

### DIFF
--- a/atox/src/main/kotlin/ui/contactlist/ContactListFragment.kt
+++ b/atox/src/main/kotlin/ui/contactlist/ContactListFragment.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2019-2024 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2021-2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
@@ -54,7 +54,7 @@ import ltd.evilcorp.domain.tox.PublicKey
 import ltd.evilcorp.domain.tox.ToxSaveStatus
 
 const val ARG_SHARE = "share"
-private const val MAX_CONFIRM_DELETE_STRING_LENGTH = 32
+private const val MAX_CONFIRM_DELETE_STRING_LENGTH = 16
 
 private fun User.online(): Boolean = connectionStatus != ConnectionStatus.None
 

--- a/core/src/main/kotlin/db/FriendRequestDao.kt
+++ b/core/src/main/kotlin/db/FriendRequestDao.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+// SPDX-FileCopyrightText: 2019-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -25,4 +25,7 @@ interface FriendRequestDao {
 
     @Query("SELECT * FROM friend_requests WHERE public_key == :publicKey")
     fun load(publicKey: String): Flow<FriendRequest>
+
+    @Query("SELECT COUNT(public_key) FROM friend_requests")
+    fun count(): Int
 }

--- a/core/src/main/kotlin/repository/FriendRequestRepository.kt
+++ b/core/src/main/kotlin/repository/FriendRequestRepository.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+// SPDX-FileCopyrightText: 2019-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -21,4 +21,6 @@ class FriendRequestRepository @Inject internal constructor(
     fun getAll(): Flow<List<FriendRequest>> = friendRequestDao.loadAll()
 
     fun get(publicKey: String): Flow<FriendRequest> = friendRequestDao.load(publicKey)
+
+    fun count(): Int = friendRequestDao.count()
 }


### PR DESCRIPTION
In order to alleviate attacks where an attacker spams a ToxID with friend requests, aTox will now discard any incoming friend requests once 32 are already active. c-toxcore saves any added friends and sends new friend requests on startup if needed, so there is no risk of requests disappearing permanently.

While receiving many thousands of friend requests failed to crash aTox, it is really annoying.