### PR TITLE
Revert the max delete-confirmation-message length to 32

### DIFF
--- a/atox/src/main/kotlin/ui/contactlist/ContactListFragment.kt
+++ b/atox/src/main/kotlin/ui/contactlist/ContactListFragment.kt
@@ -54,7 +54,7 @@ import ltd.evilcorp.domain.tox.PublicKey
 import ltd.evilcorp.domain.tox.ToxSaveStatus
 
 const val ARG_SHARE = "share"
-private const val MAX_CONFIRM_DELETE_STRING_LENGTH = 16
+private const val MAX_CONFIRM_DELETE_STRING_LENGTH = 32
 
 private fun User.online(): Boolean = connectionStatus != ConnectionStatus.None
 


### PR DESCRIPTION
This change was accidentally included in
245200d8e97a0cf0d23b0be47ae2cfc4f67d5bb7.