### PR TITLE
Fix lint warnings

### DIFF
--- a/atox/src/main/kotlin/di/DatabaseModule.kt
+++ b/atox/src/main/kotlin/di/DatabaseModule.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+// SPDX-FileCopyrightText: 2019-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -17,7 +17,6 @@ import ltd.evilcorp.core.db.FriendRequestDao
 import ltd.evilcorp.core.db.MessageDao
 import ltd.evilcorp.core.db.UserDao
 
-@Suppress("unused")
 @Module
 class DatabaseModule {
     @Singleton
@@ -28,7 +27,6 @@ class DatabaseModule {
             .build()
 }
 
-@Suppress("unused")
 @Module
 class DaoModule {
     @Singleton

--- a/atox/src/main/kotlin/ui/chat/ChatAdapter.kt
+++ b/atox/src/main/kotlin/ui/chat/ChatAdapter.kt
@@ -67,24 +67,24 @@ private enum class ChatItemType {
 private val timeFormatter = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT)
 
 private class MessageViewHolder(row: View) {
-    val message = row.findViewById(R.id.message) as TextView
-    val timestamp = row.findViewById(R.id.timestamp) as TextView
+    val message: TextView = row.findViewById(R.id.message)
+    val timestamp: TextView = row.findViewById(R.id.timestamp)
 }
 
 private class FileTransferViewHolder(row: View) {
-    val container = row.findViewById(R.id.fileTransfer) as RelativeLayout
-    val fileName = row.findViewById(R.id.fileName) as TextView
-    val fileSize = row.findViewById(R.id.fileSize) as TextView
-    val progress = row.findViewById(R.id.progress) as ProgressBar
-    val state = row.findViewById(R.id.state) as TextView
-    val timestamp = row.findViewById(R.id.timestamp) as TextView
-    val acceptLayout = row.findViewById(R.id.acceptLayout) as View
-    val accept = row.findViewById(R.id.accept) as Button
-    val reject = row.findViewById(R.id.reject) as Button
-    val cancelLayout = row.findViewById(R.id.cancelLayout) as View
-    val cancel = row.findViewById(R.id.cancel) as Button
-    val completedLayout = row.findViewById(R.id.completedLayout) as View
-    val imagePreview = row.findViewById(R.id.imagePreview) as ImageView
+    val container: RelativeLayout = row.findViewById(R.id.fileTransfer)
+    val fileName: TextView = row.findViewById(R.id.fileName)
+    val fileSize: TextView = row.findViewById(R.id.fileSize)
+    val progress: ProgressBar = row.findViewById(R.id.progress)
+    val state: TextView = row.findViewById(R.id.state)
+    val timestamp: TextView = row.findViewById(R.id.timestamp)
+    val acceptLayout: View = row.findViewById(R.id.acceptLayout)
+    val accept: Button = row.findViewById(R.id.accept)
+    val reject: Button = row.findViewById(R.id.reject)
+    val cancelLayout: View = row.findViewById(R.id.cancelLayout)
+    val cancel: Button = row.findViewById(R.id.cancel)
+    val completedLayout: View = row.findViewById(R.id.completedLayout)
+    val imagePreview: ImageView = row.findViewById(R.id.imagePreview)
 }
 
 class ChatAdapter(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ sdk-target = "33"
 
 kotlin = "1.9.23"
 ksp = "1.9.23-1.0.19"
-android-plugin = "8.3.1"
+android-plugin = "8.3.2"
 
 coroutines = "1.8.0"
 dagger = "2.48"


### PR DESCRIPTION
It would be nice to check this kind of code cleanup warnings in CI, but these ones are built into Android Studio somehow.