### PR TITLE
Improve CI stability

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,13 +49,6 @@ jobs:
       - run: ./gradlew assembleDebug
       - run: ./gradlew assembleRelease
       - run: ./gradlew build
-      - name: Run Android tests
-        if: startsWith(matrix.os, 'macos')
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 31
-          arch: x86_64
-          script: ./gradlew connectedCheck || { adb logcat -d; exit 1; }
       - name: Upload apk
         if: startsWith(matrix.os, 'ubuntu')
         uses: actions/upload-artifact@v4
@@ -63,6 +56,20 @@ jobs:
           name: atox-debug.apk
           path: ./atox/build/outputs/apk/debug/atox-debug.apk
           if-no-files-found: error
+      # https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
+      - name: Enable hardware acceleration
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Run Android tests
+        if: startsWith(matrix.os, 'ubuntu')
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 31
+          arch: x86_64
+          script: ./gradlew connectedCheck || { adb logcat -d; exit 1; }
 
   tox4j:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,8 +42,13 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/master' }}
-      - name: Build and test
-        run: ./gradlew build
+      # First build the .apks, then run things like check and lint tasks attached to the build task.
+      # We do this in multiple steps to try to reduce the peak memory usage as a plain
+      # `./gradlew build` often uses up all memory and dies in CI.
+      # See: https://issuetracker.google.com/issues/297088701
+      - run: ./gradlew assembleDebug
+      - run: ./gradlew assembleRelease
+      - run: ./gradlew build
       - name: Run Android tests
         if: startsWith(matrix.os, 'macos')
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,7 @@ jobs:
         with:
           name: atox-debug.apk
           path: ./atox/build/outputs/apk/debug/atox-debug.apk
+          if-no-files-found: error
 
   tox4j:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This step has been failing a lot in CI due to running out of memory. Doing less in each step will hopefully help.