### PR TITLE
Update protobuf, libsodium, opus, and libvpx

### DIFF
--- a/scripts/dependencies.mk
+++ b/scripts/dependencies.mk
@@ -75,7 +75,7 @@ $(DESTDIR)/tox4j-c.stamp: $(SRCDIR)/tox4j $(foreach i,jvm-toxcore-api jvm-macros
 # protobuf
 
 $(SRCDIR)/protobuf:
-	git clone --depth=1 --branch=v3.19.3 https://github.com/google/protobuf $@
+	git clone --depth=1 --branch=v21.12 https://github.com/google/protobuf $@
 
 $(PREFIX)/protobuf.stamp: $(SRCDIR)/protobuf $(TOOLCHAIN_FILE) $(PROTOC)
 	@$(PRE_RULE)
@@ -105,7 +105,7 @@ $(PREFIX)/toxcore.stamp: $(SRCDIR)/toxcore $(TOOLCHAIN_FILE) $(foreach i,libsodi
 # libsodium
 
 $(SRCDIR)/libsodium:
-	git clone --depth=1 --branch=1.0.18 https://github.com/jedisct1/libsodium $@
+	git clone --depth=1 --branch=1.0.20-RELEASE https://github.com/jedisct1/libsodium $@
 
 $(PREFIX)/libsodium.stamp: $(SRCDIR)/libsodium $(TOOLCHAIN_FILE)
 	@$(PRE_RULE)
@@ -120,7 +120,7 @@ $(PREFIX)/libsodium.stamp: $(SRCDIR)/libsodium $(TOOLCHAIN_FILE)
 # opus
 
 $(SRCDIR)/opus:
-	git clone --depth=1 --branch=v1.3.1 https://github.com/xiph/opus $@
+	git clone --depth=1 --branch=v1.4 https://github.com/xiph/opus $@
 
 $(PREFIX)/opus.stamp: $(SRCDIR)/opus $(TOOLCHAIN_FILE)
 	@$(PRE_RULE)
@@ -135,7 +135,7 @@ $(PREFIX)/opus.stamp: $(SRCDIR)/opus $(TOOLCHAIN_FILE)
 # libvpx
 
 $(SRCDIR)/libvpx:
-	git clone --depth=1 --branch=v1.11.0 https://github.com/webmproject/libvpx $@
+	git clone --depth=1 --branch=v1.14.1 https://github.com/webmproject/libvpx $@
 	cd $@ && patch -p1 < $(CURDIR)/scripts/patches/libvpx.patch
 
 $(PREFIX)/libvpx.stamp: $(SRCDIR)/libvpx $(TOOLCHAIN_FILE)


### PR DESCRIPTION
All except protobuf were updated to the latest versions.

Protobuf was updated to the latest version with support for autotools and will be migrated to being built with CMake later. Not updating protobuf to the latest version shouldn't be a big deal as it's only used internally in tox4j and is not used for serialization of data from the network.

See: #1232