### PR TITLE
Improve the chat export format

### DIFF
--- a/domain/src/main/kotlin/feature/ExportManager.kt
+++ b/domain/src/main/kotlin/feature/ExportManager.kt
@@ -12,14 +12,15 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import ltd.evilcorp.core.repository.MessageRepository
-import ltd.evilcorp.core.vo.Message
 import org.json.JSONArray
 import org.json.JSONObject
 
 class ExportManager @Inject constructor(
     private val messageRepository: MessageRepository,
 ) {
-    private fun generateExportMessagesJString(messages: List<Message>): String {
+    fun generateExportMessagesJString(publicKey: String): String {
+        val messages = runBlocking { messageRepository.get(publicKey).first() }
+
         val root = JSONObject()
         root.put("version", 1)
         root.put(
@@ -41,12 +42,4 @@ class ExportManager @Inject constructor(
         root.put("entries", entries)
         return root.toString(2)
     }
-
-    private fun getMessages(publicKey: String): List<Message> = runBlocking {
-        messageRepository.get(publicKey).first()
-    }
-
-    fun generateExportMessagesJString(publicKey: String): String = generateExportMessagesJString(
-        getMessages(publicKey),
-    )
 }

--- a/domain/src/main/kotlin/feature/ExportManager.kt
+++ b/domain/src/main/kotlin/feature/ExportManager.kt
@@ -27,11 +27,11 @@ class ExportManager @Inject constructor(
             "timestamp",
             SimpleDateFormat("""yyyy-MM-dd'T'HH-mm-ss""", Locale.getDefault()).format(Date()),
         )
+        root.put("contact_public_key", publicKey)
 
         val entries = JSONArray()
         for (message in messages) {
             val jsonMessage = JSONObject().apply {
-                put("publicKey", message.publicKey)
                 put("message", message.message)
                 put("sender", message.sender.toString())
                 put("type", message.type.toString())

--- a/domain/src/main/kotlin/feature/ExportManager.kt
+++ b/domain/src/main/kotlin/feature/ExportManager.kt
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2022 Akito <the@akito.ooo>
-// SPDX-FileCopyrightText: 2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2023-2024 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -34,9 +34,7 @@ class ExportManager @Inject constructor(
                 put("message", message.message)
                 put("sender", message.sender.toString())
                 put("type", message.type.toString())
-                put("correlationId", message.correlationId)
                 put("timestamp", message.timestamp)
-                put("id", message.id)
             }
             entries.put(jsonMessage)
         }


### PR DESCRIPTION
Before:
```json
{
  "version": 1,
  "timestamp": "2024-05-31T00-48-44",
  "entries": [
    {
      "publicKey": "REDACTEDREDACTEDREDACTED",
      "message": "I think you'll appreciate this!",
      "sender": "Sent",
      "type": "Normal",
      "correlationId": 2,
      "timestamp": 1639516454661,
      "id": 7655
    },
    {
      "publicKey": "REDACTEDREDACTEDREDACTED",
      "message": "I do appreciate this!",
      "sender": "Received",
      "type": "Normal",
      "correlationId": -2147483648,
      "timestamp": 1708474080419,
      "id": 44095
    },
...
```

After:
```json
{
  "version": 1,
  "timestamp": "2024-05-31T00-59-47",
  "contact_public_key": "REDACTEDREDACTEDREDACTED",
  "entries": [
    {
      "message": "I think you'll appreciate this!",
      "sender": "Sent",
      "type": "Normal",
      "timestamp": 1639516454661
    },
    {
      "message": "I do appreciate this!",
      "sender": "Received",
      "type": "Normal",
      "timestamp": 1708474080419
    },
...
```