### PR TITLE
Update the gradle wrapper validation action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: gradle/actions/wrapper-validation@v3
 
   gradle:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
gradle/wrapper-validation-action is deprecated in favour of this new name.