### PR TITLE
Fix tox4j artifacts no longer being uploaded in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,6 +103,7 @@ jobs:
         with:
           name: tox4j
           path: ~/.m2
+          if-no-files-found: error
           include-hidden-files: true
 
   bazel:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,6 +103,7 @@ jobs:
         with:
           name: tox4j
           path: ~/.m2
+          include-hidden-files: true
 
   bazel:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Turns out GitHub doesn't use semver for the CI actions, so using `actions/upload-artifact` like `actions/upload-artifact@v4`, the way they've documented it, will break things on occasion.