### PR TITLE
Update versions of things used in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install
         run: |
-          wget --output-document=buildifier https://github.com/bazelbuild/buildtools/releases/download/v7.1.2/buildifier-linux-amd64
+          wget --output-document=buildifier https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-linux-amd64
           sudo chmod +x buildifier
       - name: Check
         run: ./buildifier --lint=warn --warnings=all -mode diff WORKSPACE $(find . -type f -name "BUILD.*")
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - run: npm install --global prettier@3.3.1
+      - run: npm install --global prettier@3.3.3
       - run: npx prettier --ignore-path .gitignore --write .
       - run: git diff --exit-code
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   ktlint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - run: curl -sSLO https://github.com/pinterest/ktlint/releases/download/1.3.1/ktlint && chmod a+x ktlint
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macos-12
+          - macos-14
           - windows-2022
     steps:
       - name: Download tox4j
@@ -107,7 +107,7 @@ jobs:
           include-hidden-files: true
 
   bazel:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -128,7 +128,7 @@ jobs:
       - run: bazel test //...
 
   buildifier:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Install
@@ -139,7 +139,7 @@ jobs:
         run: ./buildifier --lint=warn --warnings=all -mode diff WORKSPACE $(find . -type f -name "BUILD.*")
 
   prettier:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - run: npm install --global prettier@3.3.3

--- a/.github/workflows/detekt.yaml
+++ b/.github/workflows/detekt.yaml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   detekt:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/detekt.yaml
+++ b/.github/workflows/detekt.yaml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  DETEKT_RELEASE: 1.23.6
+  DETEKT_RELEASE: 1.23.7
 
 jobs:
   detekt:


### PR DESCRIPTION
I'm leaving the tox4j+gradle jobs on 22.04 due to sbt and Android emulator issues I'll look into later.