### PR TITLE
Fix friend request messages not always being logged

### DIFF
--- a/atox/src/main/kotlin/ui/friendrequest/FriendRequestFragment.kt
+++ b/atox/src/main/kotlin/ui/friendrequest/FriendRequestFragment.kt
@@ -49,7 +49,6 @@ class FriendRequestFragment : BaseFragment<FragmentFriendRequestBinding>(Fragmen
 
         accept.setOnClickListener {
             vm.accept(friendRequest)
-            vm.addToChatLog(friendRequest)
             findNavController().popBackStack()
         }
 

--- a/atox/src/main/kotlin/ui/friendrequest/FriendRequestViewModel.kt
+++ b/atox/src/main/kotlin/ui/friendrequest/FriendRequestViewModel.kt
@@ -1,4 +1,5 @@
-// SPDX-FileCopyrightText: 2020-2022 aTox contributors
+// SPDX-FileCopyrightText: 2020-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -7,36 +8,13 @@ package ltd.evilcorp.atox.ui.friendrequest
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
-import java.util.Date
 import javax.inject.Inject
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
-import ltd.evilcorp.core.repository.MessageRepository
 import ltd.evilcorp.core.vo.FriendRequest
-import ltd.evilcorp.core.vo.Message
-import ltd.evilcorp.core.vo.MessageType
-import ltd.evilcorp.core.vo.Sender
 import ltd.evilcorp.domain.feature.FriendRequestManager
 import ltd.evilcorp.domain.tox.PublicKey
 
-class FriendRequestViewModel @Inject constructor(
-    private val scope: CoroutineScope,
-    private val friendRequests: FriendRequestManager,
-    private val messageRepository: MessageRepository,
-) : ViewModel() {
+class FriendRequestViewModel @Inject constructor(private val friendRequests: FriendRequestManager) : ViewModel() {
     fun byId(pk: PublicKey): LiveData<FriendRequest> = friendRequests.get(pk).asLiveData()
     fun accept(request: FriendRequest) = friendRequests.accept(request)
     fun reject(request: FriendRequest) = friendRequests.reject(request)
-    fun addToChatLog(request: FriendRequest) = scope.launch {
-        messageRepository.add(
-            Message(
-                request.publicKey,
-                request.message,
-                Sender.Received,
-                MessageType.Normal,
-                0,
-                Date().time,
-            ),
-        )
-    }
 }

--- a/domain/src/main/kotlin/feature/FriendRequestManager.kt
+++ b/domain/src/main/kotlin/feature/FriendRequestManager.kt
@@ -1,4 +1,5 @@
-// SPDX-FileCopyrightText: 2019-2021 Robin Lindén
+// SPDX-FileCopyrightText: 2019-2024 Robin Lindén
+// SPDX-FileCopyrightText: 2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -11,8 +12,12 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import ltd.evilcorp.core.repository.ContactRepository
 import ltd.evilcorp.core.repository.FriendRequestRepository
+import ltd.evilcorp.core.repository.MessageRepository
 import ltd.evilcorp.core.vo.Contact
 import ltd.evilcorp.core.vo.FriendRequest
+import ltd.evilcorp.core.vo.Message
+import ltd.evilcorp.core.vo.MessageType
+import ltd.evilcorp.core.vo.Sender
 import ltd.evilcorp.domain.tox.PublicKey
 import ltd.evilcorp.domain.tox.Tox
 
@@ -20,15 +25,27 @@ class FriendRequestManager @Inject constructor(
     private val scope: CoroutineScope,
     private val contactRepository: ContactRepository,
     private val friendRequestRepository: FriendRequestRepository,
+    private val messageRepository: MessageRepository,
     private val tox: Tox,
 ) {
     fun getAll(): Flow<List<FriendRequest>> = friendRequestRepository.getAll()
     fun get(id: PublicKey): Flow<FriendRequest> = friendRequestRepository.get(id.string())
 
     fun accept(friendRequest: FriendRequest) = scope.launch {
+        val acceptTime = Date().time
         tox.acceptFriendRequest(PublicKey(friendRequest.publicKey))
+        messageRepository.add(
+            Message(
+                friendRequest.publicKey,
+                friendRequest.message,
+                Sender.Received,
+                MessageType.Normal,
+                0,
+                acceptTime,
+            ),
+        )
         contactRepository.add(Contact(friendRequest.publicKey))
-        contactRepository.setLastMessage(friendRequest.publicKey, Date().time)
+        contactRepository.setLastMessage(friendRequest.publicKey, acceptTime)
         friendRequestRepository.delete(friendRequest)
     }
 


### PR DESCRIPTION
They were missing if you accepted a friend request from the long-press menu on a friend request in the contact list. This commit moves the logic for adding it down one layer, so now it can't be missed unless you skip over abstractions.

This issue was reported by @Yegorsh in #1278 