### PR TITLE
Open a chat for toxurls if the contact already exists

### DIFF
--- a/atox/src/main/kotlin/MainActivity.kt
+++ b/atox/src/main/kotlin/MainActivity.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -17,6 +17,7 @@ import androidx.navigation.fragment.findNavController
 import javax.inject.Inject
 import ltd.evilcorp.atox.di.ViewModelFactory
 import ltd.evilcorp.atox.settings.Settings
+import ltd.evilcorp.atox.ui.contactlist.ARG_ADD_CONTACT
 import ltd.evilcorp.atox.ui.contactlist.ARG_SHARE
 
 private const val TAG = "MainActivity"
@@ -89,8 +90,8 @@ class MainActivity : AppCompatActivity() {
         }
 
         supportFragmentManager.findFragmentById(R.id.nav_host_fragment)?.findNavController()?.navigate(
-            R.id.addContactFragment,
-            bundleOf("toxId" to data.drop(SCHEME.length)),
+            R.id.contactListFragment,
+            bundleOf(ARG_ADD_CONTACT to data.drop(SCHEME.length)),
         )
     }
 

--- a/atox/src/main/kotlin/ui/chat/ChatFragment.kt
+++ b/atox/src/main/kotlin/ui/chat/ChatFragment.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2021-2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
@@ -14,6 +14,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import android.view.ContextMenu
 import android.view.MenuItem
 import android.view.MotionEvent
@@ -55,6 +56,7 @@ import ltd.evilcorp.core.vo.isComplete
 import ltd.evilcorp.domain.feature.CallState
 import ltd.evilcorp.domain.tox.PublicKey
 
+private const val TAG = "ChatFragment"
 const val CONTACT_PUBLIC_KEY = "publicKey"
 const val FOCUS_ON_MESSAGE_BOX = "focusOnMessageBox"
 private const val MAX_CONFIRM_DELETE_STRING_LENGTH = 20
@@ -202,6 +204,7 @@ class ChatFragment : BaseFragment<FragmentChatBinding>(FragmentChatBinding::infl
 
         viewModel.contact.observe(viewLifecycleOwner) {
             if (it == null) {
+                Log.e(TAG, "Contact $contactPubKey does not exist, leaving chat")
                 findNavController().popBackStack()
                 return@observe
             }

--- a/atox/src/main/kotlin/ui/contactlist/ContactListFragment.kt
+++ b/atox/src/main/kotlin/ui/contactlist/ContactListFragment.kt
@@ -51,6 +51,7 @@ import ltd.evilcorp.core.vo.Contact
 import ltd.evilcorp.core.vo.FriendRequest
 import ltd.evilcorp.core.vo.User
 import ltd.evilcorp.domain.tox.PublicKey
+import ltd.evilcorp.domain.tox.ToxID
 import ltd.evilcorp.domain.tox.ToxSaveStatus
 
 const val ARG_ADD_CONTACT = "add_contact"
@@ -187,7 +188,13 @@ class ContactListFragment :
 
         arguments?.getString(ARG_ADD_CONTACT)?.let { toxId ->
             arguments?.remove(ARG_ADD_CONTACT)
-            findNavController().navigate(R.id.addContactFragment, bundleOf("toxId" to toxId))
+            val id = ToxID(toxId)
+            val pk = id.toPublicKey()
+            if (viewModel.contactAdded(pk)) {
+                openChat(pk.string())
+            } else {
+                findNavController().navigate(R.id.addContactFragment, bundleOf("toxId" to toxId))
+            }
         }
 
         arguments?.getString(ARG_SHARE)?.let { share ->
@@ -379,9 +386,10 @@ class ContactListFragment :
         }
     }
 
-    private fun openChat(contact: Contact) = findNavController().navigate(
+    private fun openChat(contact: Contact) = openChat(contact.publicKey)
+    private fun openChat(pk: String) = findNavController().navigate(
         R.id.action_contactListFragment_to_chatFragment,
-        bundleOf(CONTACT_PUBLIC_KEY to contact.publicKey),
+        bundleOf(CONTACT_PUBLIC_KEY to pk),
     )
 
     private fun openFriendRequest(friendRequest: FriendRequest) = findNavController().navigate(

--- a/atox/src/main/kotlin/ui/contactlist/ContactListFragment.kt
+++ b/atox/src/main/kotlin/ui/contactlist/ContactListFragment.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2021-2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
@@ -53,6 +53,7 @@ import ltd.evilcorp.core.vo.User
 import ltd.evilcorp.domain.tox.PublicKey
 import ltd.evilcorp.domain.tox.ToxSaveStatus
 
+const val ARG_ADD_CONTACT = "add_contact"
 const val ARG_SHARE = "share"
 private const val MAX_CONFIRM_DELETE_STRING_LENGTH = 32
 
@@ -182,6 +183,11 @@ class ContactListFragment :
             } else {
                 activity?.finish()
             }
+        }
+
+        arguments?.getString(ARG_ADD_CONTACT)?.let { toxId ->
+            arguments?.remove(ARG_ADD_CONTACT)
+            findNavController().navigate(R.id.addContactFragment, bundleOf("toxId" to toxId))
         }
 
         arguments?.getString(ARG_SHARE)?.let { share ->

--- a/atox/src/main/kotlin/ui/contactlist/ContactListViewModel.kt
+++ b/atox/src/main/kotlin/ui/contactlist/ContactListViewModel.kt
@@ -1,4 +1,5 @@
-// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -17,7 +18,9 @@ import java.io.FileOutputStream
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import ltd.evilcorp.atox.R
 import ltd.evilcorp.atox.settings.Settings
@@ -77,6 +80,10 @@ class ContactListViewModel @Inject constructor(
         scope.launch {
             fileTransferManager.deleteAll(publicKey)
         }
+    }
+
+    fun contactAdded(toxId: PublicKey): Boolean = runBlocking {
+        return@runBlocking contactManager.get(toxId).firstOrNull() != null
     }
 
     fun saveToxBackupTo(uri: Uri) = scope.launch(Dispatchers.IO) {


### PR DESCRIPTION
* Fixes tapping on a toxurl before unlocking your profile crashing; now it will instead prompt you for your password as you might expect and then proceed to the appropriate page once unlocked.
* Also implements navigating to a chat instead of the add-contact page if the contact already exists.

Resolves #1250 