### PR TITLE
Move the PublicKey type into the core library

### DIFF
--- a/atox/src/androidTest/kotlin/IntegrationTest.kt
+++ b/atox/src/androidTest/kotlin/IntegrationTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2020-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -34,8 +34,8 @@ import ltd.evilcorp.atox.di.DaoModule
 import ltd.evilcorp.atox.di.ViewModelModule
 import ltd.evilcorp.atox.tox.BootstrapNodeRegistryImpl
 import ltd.evilcorp.core.db.Database
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.domain.tox.BootstrapNodeRegistry
-import ltd.evilcorp.domain.tox.PublicKey
 import ltd.evilcorp.domain.tox.SaveManager
 import org.hamcrest.core.AllOf.allOf
 import org.junit.Rule

--- a/atox/src/main/kotlin/ActionReceiver.kt
+++ b/atox/src/main/kotlin/ActionReceiver.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2021-2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
@@ -23,12 +23,12 @@ import kotlinx.coroutines.withContext
 import ltd.evilcorp.atox.ui.NotificationHelper
 import ltd.evilcorp.core.repository.ContactRepository
 import ltd.evilcorp.core.vo.Contact
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.core.vo.UserStatus
 import ltd.evilcorp.domain.feature.CallManager
 import ltd.evilcorp.domain.feature.CallState
 import ltd.evilcorp.domain.feature.ChatManager
 import ltd.evilcorp.domain.feature.ContactManager
-import ltd.evilcorp.domain.tox.PublicKey
 import ltd.evilcorp.domain.tox.Tox
 
 const val KEY_TEXT_REPLY = "key_text_reply"

--- a/atox/src/main/kotlin/tox/EventListenerCallbacks.kt
+++ b/atox/src/main/kotlin/tox/EventListenerCallbacks.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -30,13 +30,13 @@ import ltd.evilcorp.core.vo.FileKind
 import ltd.evilcorp.core.vo.FileTransfer
 import ltd.evilcorp.core.vo.FriendRequest
 import ltd.evilcorp.core.vo.Message
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.core.vo.Sender
 import ltd.evilcorp.core.vo.UserStatus
 import ltd.evilcorp.domain.av.AudioPlayer
 import ltd.evilcorp.domain.feature.CallManager
 import ltd.evilcorp.domain.feature.ChatManager
 import ltd.evilcorp.domain.feature.FileTransferManager
-import ltd.evilcorp.domain.tox.PublicKey
 import ltd.evilcorp.domain.tox.Tox
 import ltd.evilcorp.domain.tox.ToxAvEventListener
 import ltd.evilcorp.domain.tox.ToxEventListener

--- a/atox/src/main/kotlin/tox/ToxStarter.kt
+++ b/atox/src/main/kotlin/tox/ToxStarter.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -13,9 +13,9 @@ import im.tox.tox4j.crypto.exceptions.ToxDecryptionException
 import javax.inject.Inject
 import ltd.evilcorp.atox.ToxService
 import ltd.evilcorp.atox.settings.Settings
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.domain.feature.FileTransferManager
 import ltd.evilcorp.domain.feature.UserManager
-import ltd.evilcorp.domain.tox.PublicKey
 import ltd.evilcorp.domain.tox.SaveManager
 import ltd.evilcorp.domain.tox.SaveOptions
 import ltd.evilcorp.domain.tox.Tox

--- a/atox/src/main/kotlin/ui/NotificationHelper.kt
+++ b/atox/src/main/kotlin/ui/NotificationHelper.kt
@@ -46,8 +46,8 @@ import ltd.evilcorp.atox.ui.chat.CONTACT_PUBLIC_KEY
 import ltd.evilcorp.atox.ui.chat.FOCUS_ON_MESSAGE_BOX
 import ltd.evilcorp.core.vo.Contact
 import ltd.evilcorp.core.vo.FriendRequest
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.core.vo.UserStatus
-import ltd.evilcorp.domain.tox.PublicKey
 
 private const val TAG = "NotificationHelper"
 

--- a/atox/src/main/kotlin/ui/call/CallFragment.kt
+++ b/atox/src/main/kotlin/ui/call/CallFragment.kt
@@ -1,4 +1,5 @@
-// SPDX-FileCopyrightText: 2021 aTox contributors
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2021-2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -22,8 +23,8 @@ import ltd.evilcorp.atox.requireStringArg
 import ltd.evilcorp.atox.ui.BaseFragment
 import ltd.evilcorp.atox.ui.chat.CONTACT_PUBLIC_KEY
 import ltd.evilcorp.atox.vmFactory
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.domain.feature.CallState
-import ltd.evilcorp.domain.tox.PublicKey
 
 private const val PERMISSION = Manifest.permission.RECORD_AUDIO
 

--- a/atox/src/main/kotlin/ui/call/CallViewModel.kt
+++ b/atox/src/main/kotlin/ui/call/CallViewModel.kt
@@ -15,9 +15,9 @@ import kotlinx.coroutines.launch
 import ltd.evilcorp.atox.ProximityScreenOff
 import ltd.evilcorp.atox.ui.NotificationHelper
 import ltd.evilcorp.core.vo.Contact
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.domain.feature.CallManager
 import ltd.evilcorp.domain.feature.ContactManager
-import ltd.evilcorp.domain.tox.PublicKey
 
 class CallViewModel @Inject constructor(
     private val scope: CoroutineScope,

--- a/atox/src/main/kotlin/ui/chat/ChatFragment.kt
+++ b/atox/src/main/kotlin/ui/chat/ChatFragment.kt
@@ -52,9 +52,9 @@ import ltd.evilcorp.core.vo.ConnectionStatus
 import ltd.evilcorp.core.vo.FileTransfer
 import ltd.evilcorp.core.vo.Message
 import ltd.evilcorp.core.vo.MessageType
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.core.vo.isComplete
 import ltd.evilcorp.domain.feature.CallState
-import ltd.evilcorp.domain.tox.PublicKey
 
 private const val TAG = "ChatFragment"
 const val CONTACT_PUBLIC_KEY = "publicKey"

--- a/atox/src/main/kotlin/ui/chat/ChatViewModel.kt
+++ b/atox/src/main/kotlin/ui/chat/ChatViewModel.kt
@@ -1,4 +1,5 @@
-// SPDX-FileCopyrightText: 2019-2022 aTox contributors
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -33,13 +34,13 @@ import ltd.evilcorp.core.vo.Contact
 import ltd.evilcorp.core.vo.FileTransfer
 import ltd.evilcorp.core.vo.Message
 import ltd.evilcorp.core.vo.MessageType
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.domain.feature.CallManager
 import ltd.evilcorp.domain.feature.CallState
 import ltd.evilcorp.domain.feature.ChatManager
 import ltd.evilcorp.domain.feature.ContactManager
 import ltd.evilcorp.domain.feature.ExportManager
 import ltd.evilcorp.domain.feature.FileTransferManager
-import ltd.evilcorp.domain.tox.PublicKey
 
 private const val TAG = "ChatViewModel"
 

--- a/atox/src/main/kotlin/ui/contactlist/ContactListFragment.kt
+++ b/atox/src/main/kotlin/ui/contactlist/ContactListFragment.kt
@@ -49,8 +49,8 @@ import ltd.evilcorp.atox.vmFactory
 import ltd.evilcorp.core.vo.ConnectionStatus
 import ltd.evilcorp.core.vo.Contact
 import ltd.evilcorp.core.vo.FriendRequest
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.core.vo.User
-import ltd.evilcorp.domain.tox.PublicKey
 import ltd.evilcorp.domain.tox.ToxID
 import ltd.evilcorp.domain.tox.ToxSaveStatus
 

--- a/atox/src/main/kotlin/ui/contactlist/ContactListViewModel.kt
+++ b/atox/src/main/kotlin/ui/contactlist/ContactListViewModel.kt
@@ -28,6 +28,7 @@ import ltd.evilcorp.atox.tox.ToxStarter
 import ltd.evilcorp.atox.ui.NotificationHelper
 import ltd.evilcorp.core.vo.Contact
 import ltd.evilcorp.core.vo.FriendRequest
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.core.vo.User
 import ltd.evilcorp.domain.feature.CallManager
 import ltd.evilcorp.domain.feature.ChatManager
@@ -36,7 +37,6 @@ import ltd.evilcorp.domain.feature.FileTransferManager
 import ltd.evilcorp.domain.feature.FriendRequestManager
 import ltd.evilcorp.domain.feature.UserManager
 import ltd.evilcorp.domain.tox.ProxyType
-import ltd.evilcorp.domain.tox.PublicKey
 import ltd.evilcorp.domain.tox.SaveOptions
 import ltd.evilcorp.domain.tox.Tox
 import ltd.evilcorp.domain.tox.ToxSaveStatus

--- a/atox/src/main/kotlin/ui/contactprofile/ContactProfileFragment.kt
+++ b/atox/src/main/kotlin/ui/contactprofile/ContactProfileFragment.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2021-2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
@@ -18,7 +18,7 @@ import ltd.evilcorp.atox.ui.BaseFragment
 import ltd.evilcorp.atox.ui.chat.CONTACT_PUBLIC_KEY
 import ltd.evilcorp.atox.vmFactory
 import ltd.evilcorp.core.vo.ConnectionStatus
-import ltd.evilcorp.domain.tox.PublicKey
+import ltd.evilcorp.core.vo.PublicKey
 
 class ContactProfileFragment : BaseFragment<FragmentContactProfileBinding>(FragmentContactProfileBinding::inflate) {
     private val viewModel: ContactProfileViewModel by viewModels { vmFactory }

--- a/atox/src/main/kotlin/ui/contactprofile/ContactProfileViewModel.kt
+++ b/atox/src/main/kotlin/ui/contactprofile/ContactProfileViewModel.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -9,8 +9,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import javax.inject.Inject
 import ltd.evilcorp.core.vo.Contact
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.domain.feature.ContactManager
-import ltd.evilcorp.domain.tox.PublicKey
 
 class ContactProfileViewModel @Inject constructor(contactManager: ContactManager) : ViewModel() {
     var publicKey: PublicKey = PublicKey("")

--- a/atox/src/main/kotlin/ui/createprofile/CreateProfileViewModel.kt
+++ b/atox/src/main/kotlin/ui/createprofile/CreateProfileViewModel.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020-2021 aTox contributors
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -9,9 +9,9 @@ import android.net.Uri
 import androidx.lifecycle.ViewModel
 import javax.inject.Inject
 import ltd.evilcorp.atox.tox.ToxStarter
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.core.vo.User
 import ltd.evilcorp.domain.feature.UserManager
-import ltd.evilcorp.domain.tox.PublicKey
 import ltd.evilcorp.domain.tox.Tox
 import ltd.evilcorp.domain.tox.ToxSaveStatus
 

--- a/atox/src/main/kotlin/ui/friendrequest/FriendRequestFragment.kt
+++ b/atox/src/main/kotlin/ui/friendrequest/FriendRequestFragment.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2020-2025 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
@@ -18,7 +18,7 @@ import ltd.evilcorp.atox.requireStringArg
 import ltd.evilcorp.atox.ui.BaseFragment
 import ltd.evilcorp.atox.vmFactory
 import ltd.evilcorp.core.vo.FriendRequest
-import ltd.evilcorp.domain.tox.PublicKey
+import ltd.evilcorp.core.vo.PublicKey
 
 const val FRIEND_REQUEST_PUBLIC_KEY = "FRIEND_REQUEST_PUBLIC_KEY"
 

--- a/atox/src/main/kotlin/ui/friendrequest/FriendRequestViewModel.kt
+++ b/atox/src/main/kotlin/ui/friendrequest/FriendRequestViewModel.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2020-2025 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
@@ -10,8 +10,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import javax.inject.Inject
 import ltd.evilcorp.core.vo.FriendRequest
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.domain.feature.FriendRequestManager
-import ltd.evilcorp.domain.tox.PublicKey
 
 class FriendRequestViewModel @Inject constructor(private val friendRequests: FriendRequestManager) : ViewModel() {
     fun byId(pk: PublicKey): LiveData<FriendRequest> = friendRequests.get(pk).asLiveData()

--- a/core/src/main/kotlin/vo/PublicKey.kt
+++ b/core/src/main/kotlin/vo/PublicKey.kt
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+package ltd.evilcorp.core.vo
+
+private fun hexToBytes(hex: String) = hex.chunked(2).map { it.uppercase().toInt(radix = 16).toByte() }.toByteArray()
+private fun bytesToHex(bytes: ByteArray) = bytes.joinToString(separator = "") { "%02X".format(it) }
+
+@JvmInline
+value class PublicKey(private val value: String) {
+    fun bytes() = hexToBytes(value)
+    fun string() = value
+    fun fingerprint() = value.take(8)
+
+    companion object {
+        fun fromBytes(publicKey: ByteArray) = PublicKey(bytesToHex(publicKey))
+    }
+}

--- a/domain/src/androidTest/kotlin/tox/ToxTest.kt
+++ b/domain/src/androidTest/kotlin/tox/ToxTest.kt
@@ -17,6 +17,7 @@ import ltd.evilcorp.core.db.Database
 import ltd.evilcorp.core.repository.ContactRepository
 import ltd.evilcorp.core.repository.UserRepository
 import ltd.evilcorp.core.vo.ConnectionStatus
+import ltd.evilcorp.core.vo.PublicKey
 import org.junit.runner.RunWith
 
 class FakeBootstrapNodeRegistry(val nodes: List<BootstrapNode> = listOf()) : BootstrapNodeRegistry {

--- a/domain/src/main/kotlin/feature/CallManager.kt
+++ b/domain/src/main/kotlin/feature/CallManager.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021-2022 aTox contributors
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -18,8 +18,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import ltd.evilcorp.core.vo.Contact
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.domain.av.AudioCapture
-import ltd.evilcorp.domain.tox.PublicKey
 import ltd.evilcorp.domain.tox.Tox
 
 sealed class CallState {

--- a/domain/src/main/kotlin/feature/ChatManager.kt
+++ b/domain/src/main/kotlin/feature/ChatManager.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -17,9 +17,9 @@ import ltd.evilcorp.core.repository.MessageRepository
 import ltd.evilcorp.core.vo.ConnectionStatus
 import ltd.evilcorp.core.vo.Message
 import ltd.evilcorp.core.vo.MessageType
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.core.vo.Sender
 import ltd.evilcorp.domain.tox.MAX_MESSAGE_LENGTH
-import ltd.evilcorp.domain.tox.PublicKey
 import ltd.evilcorp.domain.tox.Tox
 
 private fun String.chunked(chunkSizeInBytes: Int): MutableList<String> {

--- a/domain/src/main/kotlin/feature/ContactManager.kt
+++ b/domain/src/main/kotlin/feature/ContactManager.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2021 Robin Lindén
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -10,7 +10,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import ltd.evilcorp.core.repository.ContactRepository
 import ltd.evilcorp.core.vo.Contact
-import ltd.evilcorp.domain.tox.PublicKey
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.domain.tox.Tox
 import ltd.evilcorp.domain.tox.ToxID
 

--- a/domain/src/main/kotlin/feature/FileTransferManager.kt
+++ b/domain/src/main/kotlin/feature/FileTransferManager.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2024 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -32,11 +32,11 @@ import ltd.evilcorp.core.vo.FileKind
 import ltd.evilcorp.core.vo.FileTransfer
 import ltd.evilcorp.core.vo.Message
 import ltd.evilcorp.core.vo.MessageType
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.core.vo.Sender
 import ltd.evilcorp.core.vo.isComplete
 import ltd.evilcorp.core.vo.isStarted
 import ltd.evilcorp.domain.tox.MAX_AVATAR_SIZE
-import ltd.evilcorp.domain.tox.PublicKey
 import ltd.evilcorp.domain.tox.Tox
 
 private const val TAG = "FileTransferManager"

--- a/domain/src/main/kotlin/feature/FriendRequestManager.kt
+++ b/domain/src/main/kotlin/feature/FriendRequestManager.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2024 Robin Lindén
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
@@ -17,8 +17,8 @@ import ltd.evilcorp.core.vo.Contact
 import ltd.evilcorp.core.vo.FriendRequest
 import ltd.evilcorp.core.vo.Message
 import ltd.evilcorp.core.vo.MessageType
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.core.vo.Sender
-import ltd.evilcorp.domain.tox.PublicKey
 import ltd.evilcorp.domain.tox.Tox
 
 class FriendRequestManager @Inject constructor(

--- a/domain/src/main/kotlin/feature/UserManager.kt
+++ b/domain/src/main/kotlin/feature/UserManager.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -8,9 +8,9 @@ import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import ltd.evilcorp.core.repository.UserRepository
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.core.vo.User
 import ltd.evilcorp.core.vo.UserStatus
-import ltd.evilcorp.domain.tox.PublicKey
 import ltd.evilcorp.domain.tox.Tox
 
 class UserManager @Inject constructor(

--- a/domain/src/main/kotlin/tox/BootstrapNodeJsonParser.kt
+++ b/domain/src/main/kotlin/tox/BootstrapNodeJsonParser.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 aTox contributors
+// SPDX-FileCopyrightText: 2021-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -6,6 +6,7 @@ package ltd.evilcorp.domain.tox
 
 import android.util.Log
 import javax.inject.Inject
+import ltd.evilcorp.core.vo.PublicKey
 import org.json.JSONObject
 
 private const val TAG = "BootstrapNodeJsonParser"

--- a/domain/src/main/kotlin/tox/SaveManager.kt
+++ b/domain/src/main/kotlin/tox/SaveManager.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2022 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -10,6 +10,7 @@ import android.util.Log
 import androidx.core.util.writeBytes
 import java.io.File
 import javax.inject.Inject
+import ltd.evilcorp.core.vo.PublicKey
 
 private const val TAG = "AndroidSaveManager"
 

--- a/domain/src/main/kotlin/tox/Tox.kt
+++ b/domain/src/main/kotlin/tox/Tox.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019-2023 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
 // SPDX-FileCopyrightText: 2019-2020 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
@@ -24,6 +24,7 @@ import ltd.evilcorp.core.vo.ConnectionStatus
 import ltd.evilcorp.core.vo.Contact
 import ltd.evilcorp.core.vo.FileKind
 import ltd.evilcorp.core.vo.MessageType
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.core.vo.UserStatus
 
 private const val TAG = "Tox"

--- a/domain/src/main/kotlin/tox/ToxAvEventListener.kt
+++ b/domain/src/main/kotlin/tox/ToxAvEventListener.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 aTox contributors
+// SPDX-FileCopyrightText: 2020-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -8,6 +8,7 @@ import im.tox.tox4j.av.callbacks.ToxAvEventListener
 import im.tox.tox4j.av.enums.ToxavFriendCallState
 import java.util.EnumSet
 import javax.inject.Inject
+import ltd.evilcorp.core.vo.PublicKey
 import scala.Option
 import scala.Tuple3
 

--- a/domain/src/main/kotlin/tox/ToxEventListener.kt
+++ b/domain/src/main/kotlin/tox/ToxEventListener.kt
@@ -1,4 +1,5 @@
-// SPDX-FileCopyrightText: 2019-2020 aTox contributors
+// SPDX-FileCopyrightText: 2019 aTox contributors
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -11,6 +12,7 @@ import im.tox.tox4j.core.enums.ToxMessageType
 import im.tox.tox4j.core.enums.ToxUserStatus
 import javax.inject.Inject
 import ltd.evilcorp.core.vo.ConnectionStatus
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.core.vo.UserStatus
 
 typealias FriendLosslessPacketHandler = (publicKey: String, data: ByteArray) -> Unit

--- a/domain/src/main/kotlin/tox/ToxTypes.kt
+++ b/domain/src/main/kotlin/tox/ToxTypes.kt
@@ -1,19 +1,10 @@
-// SPDX-FileCopyrightText: 2019-2021 aTox contributors
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
 package ltd.evilcorp.domain.tox
 
-@JvmInline
-value class PublicKey(private val value: String) {
-    fun bytes() = value.hexToBytes()
-    fun string() = value
-    fun fingerprint() = value.take(8)
-
-    companion object {
-        fun fromBytes(publicKey: ByteArray) = PublicKey(publicKey.bytesToHex())
-    }
-}
+import ltd.evilcorp.core.vo.PublicKey
 
 @JvmInline
 value class ToxID(private val value: String) {

--- a/domain/src/main/kotlin/tox/ToxWrapper.kt
+++ b/domain/src/main/kotlin/tox/ToxWrapper.kt
@@ -16,6 +16,7 @@ import im.tox.tox4j.impl.jni.ToxCoreImpl
 import kotlin.random.Random
 import ltd.evilcorp.core.vo.FileKind
 import ltd.evilcorp.core.vo.MessageType
+import ltd.evilcorp.core.vo.PublicKey
 import ltd.evilcorp.core.vo.UserStatus
 
 private const val TAG = "ToxWrapper"

--- a/domain/src/test/kotlin/tox/ToxTypesTest.kt
+++ b/domain/src/test/kotlin/tox/ToxTypesTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 aTox contributors
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -6,6 +6,7 @@ package ltd.evilcorp.domain.tox
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import ltd.evilcorp.core.vo.PublicKey
 
 class ToxTypesTest {
     @Test


### PR DESCRIPTION
This is in preparation of using it in the database types now that that is a thing that's possible.

This is the non-database part of #1291. Switching to using PublicKey in the database requires rules_kotlin changes due to not supporting passing arguments to ksp/kapt processors, and that's a later problem.