### PR TITLE
Stop printing all adb logs on CI test failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
         with:
           api-level: 31
           arch: x86_64
-          script: ./gradlew connectedCheck || { adb logcat -d; exit 1; }
+          script: ./gradlew connectedCheck
 
   tox4j:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This hasn't been helpful since the emulator in CI stopped randomly crashing, and it makes opening the logs in GitHub take forever.