### PR TITLE
Fix possible race in user creation

### DIFF
--- a/atox/src/main/kotlin/ui/createprofile/CreateProfileFragment.kt
+++ b/atox/src/main/kotlin/ui/createprofile/CreateProfileFragment.kt
@@ -1,4 +1,5 @@
-// SPDX-FileCopyrightText: 2020-2021 aTox contributors
+// SPDX-FileCopyrightText: 2019-2025 Robin Lindén <dev@robinlinden.eu>
+// SPDX-FileCopyrightText: 2022 aTox contributors
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -19,6 +20,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import kotlinx.coroutines.runBlocking
 import ltd.evilcorp.atox.R
 import ltd.evilcorp.atox.databinding.FragmentProfileBinding
 import ltd.evilcorp.atox.ui.BaseFragment
@@ -95,7 +97,10 @@ class CreateProfileFragment : BaseFragment<FragmentProfileBinding>(FragmentProfi
                 name = if (username.text.isNotEmpty()) username.text.toString() else getString(R.string.name_default),
                 statusMessage = getString(R.string.status_message_default),
             )
-            viewModel.create(user)
+
+            runBlocking {
+                viewModel.create(user).join()
+            }
 
             findNavController().popBackStack()
         }


### PR DESCRIPTION
This issue showed up a lot in CI where things are a lot slower. The 
createprofile fragment spawns a coroutine that will create a user and 
returns before it's done, then the contactlist fragment will try to load 
the user, leading to a crash if the user-creation coroutine hasn't done 
its thing yet.

With this change, we wait for the user-creation coroutine to complete 
before moving to the contactlist fragment.

To reproduce the issue locally, I added a delay(1000) in UserManager::create.


Call stack from CI:
```
java.lang.IllegalStateException: The query result was empty, but expected a single row to return a NON-NULL object of type <ltd.evilcorp.core.vo.User>.
	at ltd.evilcorp.core.db.UserDao_Impl.load$lambda$3(UserDao_Impl.kt:132)
	at ltd.evilcorp.core.db.UserDao_Impl.$r8$lambda$8QDXdWcf5qEAu-VWErLGcEZTRTg(Unknown Source:0)
	at ltd.evilcorp.core.db.UserDao_Impl$$ExternalSyntheticLambda0.invoke(D8$$SyntheticClass:0)
	at androidx.room.util.DBUtil__DBUtil_androidKt$performSuspending$lambda$1$$inlined$internalPerform$1.invokeSuspend(DBUtil.kt:68)
	at androidx.room.util.DBUtil__DBUtil_androidKt$performSuspending$lambda$1$$inlined$internalPerform$1.invoke(Unknown Source:8)
	at androidx.room.util.DBUtil__DBUtil_androidKt$performSuspending$lambda$1$$inlined$internalPerform$1.invoke(Unknown Source:4)
	at androidx.room.driver.SupportSQLiteConnectionPool.useConnection(SupportSQLiteConnectionPool.android.kt:42)
	at androidx.room.RoomConnectionManager.useConnection(RoomConnectionManager.android.kt:126)
	at androidx.room.RoomDatabase.useConnection$room_runtime_release(RoomDatabase.android.kt:593)
	at androidx.room.util.DBUtil__DBUtil_androidKt$performSuspending$$inlined$compatCoroutineExecute$DBUtil__DBUtil_androidKt$1.invokeSuspend(DBUtil.android.kt:113)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
	at java.lang.Thread.run(Thread.java:920)
	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@64390f3, Dispatchers.Main.immediate]
```