### PR TITLE
Work around sbt not finding 'xsbti' when trying to build tox4j

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,11 @@ jobs:
         with:
           distribution: adopt
           java-version: 17
+      # sbt 0.13.18 is broken starting with sbt-runner 1.11.6.
+      # See: https://github.com/sbt/sbt/issues/8278
+      - uses: sbt/setup-sbt@17575ea4e18dd928fe5968dbe32294b97923d65b # v1.11.13
+        with:
+          sbt-runner-version: 1.11.5
       - name: Set up cache
         id: cache
         uses: actions/cache@v4


### PR DESCRIPTION
GitHub updated to sbt 1.11.6 in https://github.com/actions/runner-images/commit/a4fd58c8608d0bb66ff4708237588b7fcc5bb5b3, and that doesn't seem to work with sbt 0.13.18.