### PR TITLE
Make a call notification persistent

### DIFF
--- a/atox/src/main/AndroidManifest.xml
+++ b/atox/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
 
     <uses-feature android:name="android.hardware.camera" android:required="false"/>
 

--- a/atox/src/main/kotlin/ui/NotificationHelper.kt
+++ b/atox/src/main/kotlin/ui/NotificationHelper.kt
@@ -43,6 +43,7 @@ import ltd.evilcorp.atox.KEY_CONTACT_PK
 import ltd.evilcorp.atox.KEY_TEXT_REPLY
 import ltd.evilcorp.atox.PendingIntentCompat
 import ltd.evilcorp.atox.R
+import ltd.evilcorp.atox.hasPermission
 import ltd.evilcorp.atox.ui.chat.CONTACT_PUBLIC_KEY
 import ltd.evilcorp.atox.ui.chat.FOCUS_ON_MESSAGE_BOX
 import ltd.evilcorp.core.vo.Contact
@@ -311,12 +312,23 @@ class NotificationHelper @Inject constructor(private val context: Context) {
             return
         }
 
-        val notification = NotificationCompat.Builder(context, CALL)
+        val notificationBuilder = NotificationCompat.Builder(context, CALL)
+
+        val pendingIntent = deepLinkToChat(PublicKey(c.publicKey))
+        if (context.hasPermission(Manifest.permission.USE_FULL_SCREEN_INTENT)) {
+            // Making the notification persistent takes a full-screen intent.
+            notificationBuilder
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setFullScreenIntent(pendingIntent, true)
+        } else {
+            notificationBuilder.setContentIntent(pendingIntent)
+        }
+
+        val notification = notificationBuilder
             .setCategory(NotificationCompat.CATEGORY_CALL)
             .setSmallIcon(android.R.drawable.ic_menu_call)
             .setContentTitle(context.getString(R.string.incoming_call))
             .setContentText(context.getString(R.string.incoming_call_from, c.name))
-            .setContentIntent(deepLinkToChat(PublicKey(c.publicKey)))
             .addAction(
                 NotificationCompat.Action
                     .Builder(


### PR DESCRIPTION
Makes an incoming call notification (heads-up) stay on the screen as long as needed.

Requires Full-screen intent permission in the Manifest.

Closes https://github.com/evilcorpltd/aTox/issues/1316