### PR TITLE
Update the Android Gradle Plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,17 @@ org.gradle.jvmargs=-Xmx1536m
 org.gradle.caching=true
 org.gradle.parallel=true
 kotlin.code.style=official
-android.useAndroidX=true
 android.enableJetifier=false
-android.nonTransitiveRClass=true
+
+# TODO(robinlinden): Migrate away from the below flags.
+# See: https://developer.android.com/build/releases/agp-9-0-0-release-notes#android-gradle-plugin-behavior-changes
+android.builtInKotlin=false
+android.defaults.buildfeatures.resvalues=true
+android.dependency.useConstraints=true
+android.enableAppCompileTimeRClass=false
+android.newDsl=false
+android.r8.optimizedResourceShrinking=false
+android.r8.strictFullModeForKeepRules=false
+android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+android.uniquePackageNames=false
+android.usesSdkInManifest.disallowed=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ sdk-target = "35"
 
 kotlin = "2.2.20"
 ksp = "2.2.20-2.0.3"
-android-plugin = "8.13.0"
+android-plugin = "9.0.1"
 
 coroutines = "1.10.2"
 # TODO(robinlinden): dagger 2.56.x (last tested 2.56.2) results in:


### PR DESCRIPTION
`android.useAndroidX` now defaults to true, and
`android.nonTransitiveRClass` was defaulted to true in AGP 8.0.